### PR TITLE
feat(auth-spa): account REST API layer and AuthSpa config [CP2]

### DIFF
--- a/docs/AUTH_SPA_MIGRATION.md
+++ b/docs/AUTH_SPA_MIGRATION.md
@@ -1,0 +1,47 @@
+# Auth SPA Migration
+
+Blogsphere is introducing a dedicated Angular Auth SPA (`Blogsphere.Auth.Webapp`) to replace Identity Server Razor account pages over time. Until the feature flag is enabled, **Razor pages remain the production path** and must not be removed.
+
+## Feature flag
+
+Identity Server reads `AuthSpa:Enabled` from configuration (`AuthSpaOptions` in `HostingExtensions.cs`):
+
+```json
+"AuthSpa": {
+  "Enabled": false,
+  "BaseUrl": "http://localhost:4201"
+}
+```
+
+| Setting | Default | Purpose |
+|---------|---------|---------|
+| `Enabled` | `false` | When `false`, OIDC/login redirects continue to Razor `/Account/*` pages. When `true`, redirects target the Auth SPA routes. |
+| `BaseUrl` | `http://localhost:4201` | Root URL of the Auth SPA (dev: `ng serve --port 4201`). |
+
+## Current state
+
+- **Razor pages**: Still served under `/Account/*` (login, logout, consent, device flow, grants, password flows, etc.).
+- **Auth SPA**: Parallel implementation at `Blogsphere.Auth.Webapp` calling `/api/account/*` JSON endpoints on Identity Server.
+- **Management Webapp**: `useAuthSpa: false` by default in `environment.ts`. When set to `true`, password reset and account manage links use `authSpaBaseUrl` instead of Razor URLs.
+
+## Enabling the Auth SPA (future)
+
+1. Deploy `Blogsphere.Auth.Webapp` and set `AuthSpa:BaseUrl` to its public URL.
+2. Set `AuthSpa:Enabled` to `true` in Identity Server configuration.
+3. Set `useAuthSpa: true` in the Management Webapp environment for the target deployment.
+4. Verify OIDC authorize/login, logout, consent, and password flows end-to-end.
+
+## Do not remove Razor yet
+
+Razor account UI is required for rollback and for environments where `AuthSpa:Enabled` is `false`. Remove Razor pages only after the Auth SPA is validated in all environments and the flag defaults to enabled.
+
+## Local development
+
+```bash
+# Identity Server (port 5000)
+# Auth SPA
+cd Blogsphere.Auth.Webapp
+npm start   # http://localhost:4201
+```
+
+The Auth SPA expects `environment.authority` to point at Identity Server and uses cookie + XSRF for `/api/account` calls.

--- a/src/IdentityService/Configurations/AuthSpaOptions.cs
+++ b/src/IdentityService/Configurations/AuthSpaOptions.cs
@@ -1,0 +1,10 @@
+namespace IdentityService.Configurations;
+
+public class AuthSpaOptions
+{
+    public const string SectionName = "AuthSpa";
+
+    public bool Enabled { get; set; }
+
+    public string BaseUrl { get; set; } = "http://localhost:4201";
+}

--- a/src/IdentityService/Controllers/AccountController.cs
+++ b/src/IdentityService/Controllers/AccountController.cs
@@ -1,0 +1,301 @@
+using Duende.IdentityServer.Extensions;
+using IdentityService.Models.Api.Account;
+using IdentityService.Services.Account;
+using Microsoft.AspNetCore.Antiforgery;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+
+namespace IdentityService.Controllers;
+
+[ApiController]
+[Route("api/account")]
+[AllowAnonymous]
+[AutoValidateAntiforgeryToken]
+public class AccountController(
+    IAntiforgery antiforgery,
+    ILoginFlowService loginFlowService,
+    ITwoFactorFlowService twoFactorFlowService,
+    IPasswordFlowService passwordFlowService,
+    ILogoutFlowService logoutFlowService,
+    IConsentFlowService consentFlowService,
+    IDeviceFlowService deviceFlowService,
+    IGrantsFlowService grantsFlowService) : ControllerBase
+{
+    [HttpGet("antiforgery")]
+    [IgnoreAntiforgeryToken]
+    public IActionResult GetAntiforgery()
+    {
+        var tokens = antiforgery.GetAndStoreTokens(HttpContext);
+        return Ok(new AntiforgeryResponse { Token = tokens.RequestToken });
+    }
+
+    [HttpGet("login/context")]
+    [IgnoreAntiforgeryToken]
+    public async Task<IActionResult> GetLoginContext([FromQuery] string returnUrl)
+    {
+        var isAuthenticated = User.IsAuthenticated();
+        var context = await loginFlowService.GetLoginContextAsync(returnUrl, isAuthenticated);
+
+        if (isAuthenticated)
+        {
+            return Ok(context);
+        }
+
+        if (context.IsExternalLoginOnly)
+        {
+            return Ok(new LoginResponse
+            {
+                Outcome = LoginOutcome.ExternalLoginOnly,
+                ExternalLoginScheme = context.ExternalLoginScheme,
+                RedirectUrl = $"/ExternalLogin/Challenge?scheme={Uri.EscapeDataString(context.ExternalLoginScheme)}&returnUrl={Uri.EscapeDataString(context.ReturnUrl)}"
+            });
+        }
+
+        return Ok(context);
+    }
+
+    [HttpPost("login")]
+    public async Task<IActionResult> Login([FromBody] LoginRequest request)
+    {
+        var result = await loginFlowService.LoginAsync(request);
+        return MapLoginResponse(result);
+    }
+
+    [HttpPost("login/cancel")]
+    public async Task<IActionResult> CancelLogin([FromBody] LoginCancelRequest request)
+    {
+        var result = await loginFlowService.CancelLoginAsync(request);
+        return Ok(result);
+    }
+
+    [HttpPost("two-factor/verify")]
+    public async Task<IActionResult> VerifyTwoFactor([FromBody] TwoFactorVerifyRequest request)
+    {
+        var result = await twoFactorFlowService.VerifyAsync(request);
+        return MapTwoFactorResponse(result);
+    }
+
+    [HttpPost("two-factor/resend")]
+    public async Task<IActionResult> ResendTwoFactor([FromBody] TwoFactorResendRequest request)
+    {
+        var result = await twoFactorFlowService.ResendAsync(request);
+        return MapTwoFactorResponse(result);
+    }
+
+    [HttpGet("logout/context")]
+    [IgnoreAntiforgeryToken]
+    public async Task<IActionResult> GetLogoutContext([FromQuery] string logoutId)
+    {
+        var context = await logoutFlowService.GetLogoutContextAsync(logoutId, User);
+        return Ok(context);
+    }
+
+    [HttpPost("logout")]
+    public async Task<IActionResult> Logout([FromBody] LogoutRequest request)
+    {
+        var result = await logoutFlowService.LogoutAsync(request, User, BuildLoggedOutUrl);
+
+        if (result.Outcome == LogoutOutcome.FederatedSignOutRequired)
+        {
+            return Ok(result);
+        }
+
+        return Ok(result);
+    }
+
+    [HttpPost("forgot-password")]
+    public async Task<IActionResult> ForgotPassword([FromBody] ForgotPasswordRequest request)
+    {
+        var result = await passwordFlowService.ForgotPasswordAsync(request);
+
+        if (result.FieldErrors?.Errors.Count > 0)
+        {
+            return BadRequest(result);
+        }
+
+        return Ok(result);
+    }
+
+    [HttpPost("reset-password/validate")]
+    public async Task<IActionResult> ValidateResetToken([FromBody] ValidateResetTokenRequest request)
+    {
+        var result = await passwordFlowService.ValidateResetTokenAsync(request);
+        return Ok(result);
+    }
+
+    [HttpPost("reset-password")]
+    public async Task<IActionResult> ResetPassword([FromBody] ResetPasswordRequest request)
+    {
+        var result = await passwordFlowService.ResetPasswordAsync(request);
+
+        if (result.FieldErrors?.Errors.Count > 0)
+        {
+            return BadRequest(result);
+        }
+
+        if (!result.Success)
+        {
+            return BadRequest(result);
+        }
+
+        return Ok(result);
+    }
+
+    [HttpPost("self-reset-password/send-code")]
+    [Authorize]
+    public async Task<IActionResult> SelfResetSendCode([FromBody] SelfResetPasswordSendCodeRequest request)
+    {
+        var result = await passwordFlowService.SelfResetSendCodeAsync(User, request);
+        return Ok(result);
+    }
+
+    [HttpPost("self-reset-password/verify-code")]
+    [Authorize]
+    public async Task<IActionResult> SelfResetVerifyCode([FromBody] SelfResetPasswordVerifyCodeRequest request)
+    {
+        var result = await passwordFlowService.SelfResetVerifyCodeAsync(User, request);
+
+        if (result.FieldErrors?.Errors.Count > 0)
+        {
+            return BadRequest(result);
+        }
+
+        return Ok(result);
+    }
+
+    [HttpPost("self-reset-password/change-password")]
+    [Authorize]
+    public async Task<IActionResult> SelfResetChangePassword([FromBody] SelfResetPasswordChangeRequest request)
+    {
+        var result = await passwordFlowService.SelfResetChangePasswordAsync(User, request);
+
+        if (result.FieldErrors?.Errors.Count > 0)
+        {
+            return BadRequest(result);
+        }
+
+        return Ok(result);
+    }
+
+    [HttpGet("manage")]
+    [Authorize]
+    public IActionResult GetManage()
+    {
+        return StatusCode(StatusCodes.Status501NotImplemented, new ManageStubResponse
+        {
+            Implemented = false,
+            Message = "Account management is not yet implemented via API."
+        });
+    }
+
+    [HttpPost("manage")]
+    [Authorize]
+    public IActionResult PostManage()
+    {
+        return StatusCode(StatusCodes.Status501NotImplemented, new ManageStubResponse
+        {
+            Implemented = false,
+            Message = "Account management is not yet implemented via API."
+        });
+    }
+
+    [HttpGet("consent/context")]
+    [Authorize]
+    [IgnoreAntiforgeryToken]
+    public async Task<IActionResult> GetConsentContext([FromQuery] string returnUrl)
+    {
+        var result = await consentFlowService.GetContextAsync(returnUrl);
+
+        if (result == null)
+        {
+            return NotFound();
+        }
+
+        return Ok(result);
+    }
+
+    [HttpPost("consent")]
+    [Authorize]
+    public async Task<IActionResult> SubmitConsent([FromBody] ConsentSubmitRequest request)
+    {
+        var result = await consentFlowService.SubmitAsync(request, User);
+
+        if (!result.Success)
+        {
+            return BadRequest(result);
+        }
+
+        return Ok(result);
+    }
+
+    [HttpGet("device/context")]
+    [Authorize]
+    [IgnoreAntiforgeryToken]
+    public async Task<IActionResult> GetDeviceContext([FromQuery] string userCode)
+    {
+        var result = await deviceFlowService.GetContextAsync(userCode);
+
+        if (!result.Success)
+        {
+            return BadRequest(result);
+        }
+
+        return Ok(result);
+    }
+
+    [HttpPost("device")]
+    [Authorize]
+    public async Task<IActionResult> SubmitDevice([FromBody] DeviceSubmitRequest request)
+    {
+        var result = await deviceFlowService.SubmitAsync(request, User);
+
+        if (!result.Success)
+        {
+            return BadRequest(result);
+        }
+
+        return Ok(result);
+    }
+
+    [HttpGet("grants")]
+    [Authorize]
+    [IgnoreAntiforgeryToken]
+    public async Task<IActionResult> GetGrants()
+    {
+        var result = await grantsFlowService.GetGrantsAsync(User);
+        return Ok(result);
+    }
+
+    [HttpPost("grants/revoke")]
+    [Authorize]
+    public async Task<IActionResult> RevokeGrant([FromBody] RevokeGrantRequest request)
+    {
+        var result = await grantsFlowService.RevokeGrantAsync(request, User);
+        return Ok(result);
+    }
+
+    private IActionResult MapLoginResponse(LoginResponse result)
+    {
+        return result.Outcome switch
+        {
+            LoginOutcome.Failed => BadRequest(result),
+            LoginOutcome.LockedOut => StatusCode(StatusCodes.Status423Locked, result),
+            _ => Ok(result)
+        };
+    }
+
+    private IActionResult MapTwoFactorResponse(TwoFactorResponse result)
+    {
+        return result.Outcome switch
+        {
+            TwoFactorOutcome.Failed => BadRequest(result),
+            TwoFactorOutcome.SessionExpired => BadRequest(result),
+            _ => Ok(result)
+        };
+    }
+
+    private string BuildLoggedOutUrl(string logoutId)
+    {
+        return Url.Page("/Account/Logout/LoggedOut", values: new { logoutId }) ?? "/Account/Logout/LoggedOut";
+    }
+}

--- a/src/IdentityService/HostingExtensions.cs
+++ b/src/IdentityService/HostingExtensions.cs
@@ -4,6 +4,7 @@ using IdentityService.Entities;
 using IdentityService.Models;
 using IdentityService.Security;
 using IdentityService.Services;
+using IdentityService.Services.Account;
 using IdentityService.Management.Data;
 using IdentityService.Management.Entities;
 using IdentityService.Management.Security;
@@ -25,6 +26,8 @@ internal static class HostingExtensions
 {
     public static WebApplication ConfigureServices(this WebApplicationBuilder builder)
     {
+        builder.Services.Configure<AuthSpaOptions>(builder.Configuration.GetSection(AuthSpaOptions.SectionName));
+
         // Configure Razor Pages with JSON serialization
         builder.Services.AddRazorPages()
             .AddNewtonsoftJson(config =>
@@ -32,6 +35,21 @@ internal static class HostingExtensions
                 config.UseCamelCasing(true);
                 config.SerializerSettings.Converters.Add(new StringEnumConverter());
             });
+
+        builder.Services.AddControllers()
+            .AddNewtonsoftJson(config =>
+            {
+                config.UseCamelCasing(true);
+                config.SerializerSettings.Converters.Add(new StringEnumConverter());
+            });
+
+        builder.Services.AddMemoryCache();
+        builder.Services.AddHttpContextAccessor();
+
+        builder.Services.AddAntiforgery(options =>
+        {
+            options.HeaderName = "X-XSRF-TOKEN";
+        });
 
         // Configure Database Contexts
         ConfigureDatabaseContexts(builder);
@@ -160,6 +178,7 @@ internal static class HostingExtensions
     private static void ConfigureIdentityServer(WebApplicationBuilder builder)
     {
         var certificateSettings = builder.Configuration.GetSection(CertificateSettings.OptionName).Get<CertificateSettings>();
+        var authSpaOptions = builder.Configuration.GetSection(AuthSpaOptions.SectionName).Get<AuthSpaOptions>() ?? new AuthSpaOptions();
 
         var cert = new X509Certificate2(
             Path.Combine(builder.Environment.ContentRootPath, certificateSettings.Path),
@@ -183,6 +202,16 @@ internal static class HostingExtensions
 
             // Disable automatic key management (requires license, using developer credential instead)
             options.KeyManagement.Enabled = false;
+
+            if (authSpaOptions.Enabled && !string.IsNullOrWhiteSpace(authSpaOptions.BaseUrl))
+            {
+                var spaBaseUrl = authSpaOptions.BaseUrl.TrimEnd('/');
+                options.UserInteraction.LoginUrl = $"{spaBaseUrl}/login";
+                options.UserInteraction.LogoutUrl = $"{spaBaseUrl}/logout";
+                options.UserInteraction.ConsentUrl = $"{spaBaseUrl}/consent";
+                options.UserInteraction.ErrorUrl = $"{spaBaseUrl}/error";
+                options.UserInteraction.DeviceVerificationUrl = $"{spaBaseUrl}/device";
+            }
         })
         .AddInMemoryIdentityResources(Config.IdentityResources)
         .AddInMemoryApiScopes(Config.ApiScopes)
@@ -225,6 +254,16 @@ internal static class HostingExtensions
         // Authentication services
         builder.Services.AddScoped<IApplicationUserAuthenticationService, ApplicationUserAuthenticationService>();
         builder.Services.AddScoped<IManagementUserAuthenticationService, ManagementUserAuthenticationService>();
+
+        // Account API flow services
+        builder.Services.AddSingleton<ITwoFactorPendingStore, TwoFactorPendingStore>();
+        builder.Services.AddScoped<ILoginFlowService, LoginFlowService>();
+        builder.Services.AddScoped<ITwoFactorFlowService, TwoFactorFlowService>();
+        builder.Services.AddScoped<IPasswordFlowService, PasswordFlowService>();
+        builder.Services.AddScoped<ILogoutFlowService, LogoutFlowService>();
+        builder.Services.AddScoped<IConsentFlowService, ConsentFlowService>();
+        builder.Services.AddScoped<IDeviceFlowService, DeviceFlowService>();
+        builder.Services.AddScoped<IGrantsFlowService, GrantsFlowService>();
     }
 
     private static void ConfigureExternalServices(WebApplicationBuilder builder)
@@ -250,7 +289,7 @@ internal static class HostingExtensions
         builder.Services.AddCors(options =>
         {
             options.AddPolicy(Constants.AppCorsPolicy, policy =>
-                policy.WithOrigins("http://localhost:4200")
+                policy.WithOrigins("http://localhost:4200", "http://localhost:4201")
                       .AllowAnyHeader()
                       .AllowAnyMethod()
                       .AllowCredentials());
@@ -279,6 +318,7 @@ internal static class HostingExtensions
         app.MapGet("/account/session/check", () => Results.Ok())
             .RequireAuthorization()
             .RequireCors(Constants.AppCorsPolicy);
+        app.MapControllers();
         app.MapRazorPages().RequireAuthorization();
 
         return app;

--- a/src/IdentityService/Models/Api/Account/AntiforgeryResponse.cs
+++ b/src/IdentityService/Models/Api/Account/AntiforgeryResponse.cs
@@ -1,0 +1,8 @@
+namespace IdentityService.Models.Api.Account;
+
+public class AntiforgeryResponse
+{
+    public string Token { get; set; }
+
+    public string HeaderName { get; set; } = "X-XSRF-TOKEN";
+}

--- a/src/IdentityService/Models/Api/Account/ConsentDtos.cs
+++ b/src/IdentityService/Models/Api/Account/ConsentDtos.cs
@@ -1,0 +1,153 @@
+namespace IdentityService.Models.Api.Account;
+
+public class ConsentContextRequest
+{
+    public string ReturnUrl { get; set; }
+}
+
+public class ConsentScopeDto
+{
+    public string Name { get; set; }
+
+    public string Value { get; set; }
+
+    public string DisplayName { get; set; }
+
+    public string Description { get; set; }
+
+    public bool Emphasize { get; set; }
+
+    public bool Required { get; set; }
+
+    public bool Checked { get; set; }
+}
+
+public class ConsentContextResponse
+{
+    public string ClientName { get; set; }
+
+    public string ClientUrl { get; set; }
+
+    public string ClientLogoUrl { get; set; }
+
+    public bool AllowRememberConsent { get; set; }
+
+    public string ReturnUrl { get; set; }
+
+    public IEnumerable<ConsentScopeDto> IdentityScopes { get; set; } = [];
+
+    public IEnumerable<ConsentScopeDto> ApiScopes { get; set; } = [];
+}
+
+public class ConsentSubmitRequest
+{
+    public string ReturnUrl { get; set; }
+
+    public string Button { get; set; }
+
+    public bool RememberConsent { get; set; }
+
+    public IEnumerable<string> ScopesConsented { get; set; } = [];
+
+    public string Description { get; set; }
+}
+
+public class ConsentSubmitResponse
+{
+    public bool Success { get; set; }
+
+    public string RedirectUrl { get; set; }
+
+    public bool IsNativeClient { get; set; }
+
+    public FieldErrorsDto FieldErrors { get; set; }
+}
+
+public class DeviceContextRequest
+{
+    public string UserCode { get; set; }
+}
+
+public class DeviceContextResponse
+{
+    public bool Success { get; set; }
+
+    public string UserCode { get; set; }
+
+    public string ClientName { get; set; }
+
+    public string ClientUrl { get; set; }
+
+    public string ClientLogoUrl { get; set; }
+
+    public bool AllowRememberConsent { get; set; }
+
+    public IEnumerable<ConsentScopeDto> IdentityScopes { get; set; } = [];
+
+    public IEnumerable<ConsentScopeDto> ApiScopes { get; set; } = [];
+}
+
+public class DeviceSubmitRequest
+{
+    public string UserCode { get; set; }
+
+    public string Button { get; set; }
+
+    public bool RememberConsent { get; set; }
+
+    public IEnumerable<string> ScopesConsented { get; set; } = [];
+
+    public string Description { get; set; }
+}
+
+public class DeviceSubmitResponse
+{
+    public bool Success { get; set; }
+
+    public string RedirectUrl { get; set; }
+
+    public FieldErrorsDto FieldErrors { get; set; }
+}
+
+public class GrantDto
+{
+    public string ClientId { get; set; }
+
+    public string ClientName { get; set; }
+
+    public string ClientUrl { get; set; }
+
+    public string ClientLogoUrl { get; set; }
+
+    public string Description { get; set; }
+
+    public DateTime Created { get; set; }
+
+    public DateTime? Expires { get; set; }
+
+    public IEnumerable<string> IdentityGrantNames { get; set; } = [];
+
+    public IEnumerable<string> ApiGrantNames { get; set; } = [];
+}
+
+public class GrantsListResponse
+{
+    public IEnumerable<GrantDto> Grants { get; set; } = [];
+}
+
+public class RevokeGrantRequest
+{
+    public string ClientId { get; set; }
+}
+
+public class RevokeGrantResponse
+{
+    public bool Success { get; set; }
+}
+
+public class ManageStubResponse
+{
+    public bool Implemented { get; set; }
+
+    public string Message { get; set; }
+}

--- a/src/IdentityService/Models/Api/Account/FieldErrorsDto.cs
+++ b/src/IdentityService/Models/Api/Account/FieldErrorsDto.cs
@@ -1,0 +1,6 @@
+namespace IdentityService.Models.Api.Account;
+
+public class FieldErrorsDto
+{
+    public Dictionary<string, string[]> Errors { get; set; } = new();
+}

--- a/src/IdentityService/Models/Api/Account/LoginDtos.cs
+++ b/src/IdentityService/Models/Api/Account/LoginDtos.cs
@@ -1,0 +1,71 @@
+namespace IdentityService.Models.Api.Account;
+
+public class LoginContextResponse
+{
+    public bool AllowRememberLogin { get; set; }
+
+    public bool EnableLocalLogin { get; set; }
+
+    public bool ShowSignup { get; set; }
+
+    public string ReturnUrl { get; set; }
+
+    public string Username { get; set; }
+
+    public bool IsExternalLoginOnly { get; set; }
+
+    public string ExternalLoginScheme { get; set; }
+
+    public bool IsAuthenticated { get; set; }
+
+    public IEnumerable<ExternalProviderDto> ExternalProviders { get; set; } = [];
+}
+
+public class ExternalProviderDto
+{
+    public string AuthenticationScheme { get; set; }
+
+    public string DisplayName { get; set; }
+}
+
+public class LoginRequest
+{
+    public string Username { get; set; }
+
+    public string Password { get; set; }
+
+    public bool RememberLogin { get; set; }
+
+    public string ReturnUrl { get; set; }
+}
+
+public class LoginCancelRequest
+{
+    public string ReturnUrl { get; set; }
+}
+
+public enum LoginOutcome
+{
+    Success,
+    RequiresTwoFactor,
+    Failed,
+    LockedOut,
+    Cancelled,
+    ExternalLoginOnly,
+    AlreadyAuthenticated
+}
+
+public class LoginResponse
+{
+    public LoginOutcome Outcome { get; set; }
+
+    public string RedirectUrl { get; set; }
+
+    public bool IsNativeClient { get; set; }
+
+    public string TwoFactorSessionId { get; set; }
+
+    public string ExternalLoginScheme { get; set; }
+
+    public FieldErrorsDto FieldErrors { get; set; }
+}

--- a/src/IdentityService/Models/Api/Account/LogoutDtos.cs
+++ b/src/IdentityService/Models/Api/Account/LogoutDtos.cs
@@ -1,0 +1,33 @@
+namespace IdentityService.Models.Api.Account;
+
+public class LogoutRequest
+{
+    public string LogoutId { get; set; }
+}
+
+public enum LogoutOutcome
+{
+    Success,
+    FederatedSignOutRequired,
+    NotAuthenticated
+}
+
+public class LogoutResponse
+{
+    public LogoutOutcome Outcome { get; set; }
+
+    public string RedirectUrl { get; set; }
+
+    public string LogoutId { get; set; }
+
+    public string FederatedSignOutScheme { get; set; }
+}
+
+public class LogoutContextResponse
+{
+    public bool ShowLogoutPrompt { get; set; }
+
+    public string LogoutId { get; set; }
+
+    public bool IsAuthenticated { get; set; }
+}

--- a/src/IdentityService/Models/Api/Account/PasswordDtos.cs
+++ b/src/IdentityService/Models/Api/Account/PasswordDtos.cs
@@ -1,0 +1,105 @@
+namespace IdentityService.Models.Api.Account;
+
+public class ForgotPasswordRequest
+{
+    public string Email { get; set; }
+
+    public string ReturnUrl { get; set; }
+
+    public string ClientId { get; set; }
+}
+
+public class ForgotPasswordResponse
+{
+    public bool Success { get; set; }
+
+    public string Message { get; set; }
+
+    public FieldErrorsDto FieldErrors { get; set; }
+}
+
+public class ValidateResetTokenRequest
+{
+    public string Email { get; set; }
+
+    public string Token { get; set; }
+
+    public string ReturnUrl { get; set; }
+
+    public string ClientId { get; set; }
+}
+
+public class ValidateResetTokenResponse
+{
+    public bool IsValid { get; set; }
+
+    public string ReturnUrl { get; set; }
+}
+
+public class ResetPasswordRequest
+{
+    public string Email { get; set; }
+
+    public string Token { get; set; }
+
+    public string Password { get; set; }
+
+    public string ConfirmPassword { get; set; }
+
+    public string ReturnUrl { get; set; }
+
+    public string ClientId { get; set; }
+}
+
+public class ResetPasswordResponse
+{
+    public bool Success { get; set; }
+
+    public string RedirectUrl { get; set; }
+
+    public string Message { get; set; }
+
+    public FieldErrorsDto FieldErrors { get; set; }
+}
+
+public class SelfResetPasswordSendCodeRequest
+{
+    public string ReturnUrl { get; set; }
+
+    public string ClientId { get; set; }
+}
+
+public class SelfResetPasswordVerifyCodeRequest
+{
+    public string OneTimeCode { get; set; }
+
+    public string ReturnUrl { get; set; }
+
+    public string ClientId { get; set; }
+}
+
+public class SelfResetPasswordChangeRequest
+{
+    public string Mode { get; set; } = "current";
+
+    public string CurrentPassword { get; set; }
+
+    public string NewPassword { get; set; }
+
+    public string ConfirmPassword { get; set; }
+
+    public string ReturnUrl { get; set; }
+
+    public string ClientId { get; set; }
+}
+
+public class SelfResetPasswordResponse
+{
+    public bool Success { get; set; }
+
+    public string RedirectUrl { get; set; }
+
+    public string Message { get; set; }
+
+    public FieldErrorsDto FieldErrors { get; set; }
+}

--- a/src/IdentityService/Models/Api/Account/TwoFactorDtos.cs
+++ b/src/IdentityService/Models/Api/Account/TwoFactorDtos.cs
@@ -1,0 +1,33 @@
+namespace IdentityService.Models.Api.Account;
+
+public class TwoFactorVerifyRequest
+{
+    public string TwoFactorSessionId { get; set; }
+
+    public string Code { get; set; }
+}
+
+public class TwoFactorResendRequest
+{
+    public string TwoFactorSessionId { get; set; }
+}
+
+public enum TwoFactorOutcome
+{
+    Success,
+    Failed,
+    SessionExpired
+}
+
+public class TwoFactorResponse
+{
+    public TwoFactorOutcome Outcome { get; set; }
+
+    public string RedirectUrl { get; set; }
+
+    public bool IsNativeClient { get; set; }
+
+    public string StatusMessage { get; set; }
+
+    public FieldErrorsDto FieldErrors { get; set; }
+}

--- a/src/IdentityService/Services/Account/ConsentFlowService.cs
+++ b/src/IdentityService/Services/Account/ConsentFlowService.cs
@@ -1,0 +1,155 @@
+using System.Security.Claims;
+using Duende.IdentityServer.Events;
+using Duende.IdentityServer.Extensions;
+using Duende.IdentityServer.Models;
+using Duende.IdentityServer.Services;
+using Duende.IdentityServer.Validation;
+using IdentityModel;
+using IdentityService.Models.Api.Account;
+using IdentityService.Pages.Consent;
+using IdentityService.Security;
+using Telemetry = IdentityService.Pages.Telemetry;
+
+namespace IdentityService.Services.Account;
+
+public class ConsentFlowService(IIdentityServerInteractionService interaction, IEventService events) : IConsentFlowService
+{
+    public async Task<ConsentContextResponse> GetContextAsync(string returnUrl)
+    {
+        var safeReturnUrl = ReturnUrlGuard.NormalizeForIdentityFlow(returnUrl);
+        var request = await interaction.GetAuthorizationContextAsync(safeReturnUrl);
+
+        if (request == null)
+        {
+            return null;
+        }
+
+        return CreateConsentContext(request, safeReturnUrl);
+    }
+
+    public async Task<ConsentSubmitResponse> SubmitAsync(ConsentSubmitRequest request, ClaimsPrincipal user)
+    {
+        request.ReturnUrl = ReturnUrlGuard.NormalizeForIdentityFlow(request.ReturnUrl);
+        var authRequest = await interaction.GetAuthorizationContextAsync(request.ReturnUrl);
+
+        if (authRequest == null)
+        {
+            return new ConsentSubmitResponse { Success = false };
+        }
+
+        ConsentResponse grantedConsent = null;
+        var fieldErrors = new FieldErrorsDto();
+
+        if (request.Button == "no")
+        {
+            grantedConsent = new ConsentResponse { Error = AuthorizationError.AccessDenied };
+            await events.RaiseAsync(new ConsentDeniedEvent(user.GetSubjectId(), authRequest.Client.ClientId, authRequest.ValidatedResources.RawScopeValues));
+            Telemetry.Metrics.ConsentDenied(authRequest.Client.ClientId, authRequest.ValidatedResources.ParsedScopes.Select(s => s.ParsedName));
+        }
+        else if (request.Button == "yes")
+        {
+            if (request.ScopesConsented.Any())
+            {
+                var scopes = request.ScopesConsented.ToList();
+                if (ConsentOptions.EnableOfflineAccess == false)
+                {
+                    scopes = scopes.Where(x => x != Duende.IdentityServer.IdentityServerConstants.StandardScopes.OfflineAccess).ToList();
+                }
+
+                grantedConsent = new ConsentResponse
+                {
+                    RememberConsent = request.RememberConsent,
+                    ScopesValuesConsented = scopes.ToArray(),
+                    Description = request.Description
+                };
+
+                await events.RaiseAsync(new ConsentGrantedEvent(user.GetSubjectId(), authRequest.Client.ClientId, authRequest.ValidatedResources.RawScopeValues, grantedConsent.ScopesValuesConsented, grantedConsent.RememberConsent));
+                Telemetry.Metrics.ConsentGranted(authRequest.Client.ClientId, grantedConsent.ScopesValuesConsented, grantedConsent.RememberConsent);
+                var denied = authRequest.ValidatedResources.ParsedScopes.Select(s => s.ParsedName).Except(grantedConsent.ScopesValuesConsented);
+                Telemetry.Metrics.ConsentDenied(authRequest.Client.ClientId, denied);
+            }
+            else
+            {
+                fieldErrors.Errors[""] = [ConsentOptions.MustChooseOneErrorMessage];
+            }
+        }
+        else
+        {
+            fieldErrors.Errors[""] = [ConsentOptions.InvalidSelectionErrorMessage];
+        }
+
+        if (grantedConsent != null)
+        {
+            await interaction.GrantConsentAsync(authRequest, grantedConsent);
+
+            return new ConsentSubmitResponse
+            {
+                Success = true,
+                RedirectUrl = request.ReturnUrl,
+                IsNativeClient = IdentityFlowHelpers.IsNativeClient(authRequest)
+            };
+        }
+
+        return new ConsentSubmitResponse { Success = false, FieldErrors = fieldErrors };
+    }
+
+    private static ConsentContextResponse CreateConsentContext(AuthorizationRequest request, string returnUrl)
+    {
+        var identityScopes = request.ValidatedResources.Resources.IdentityResources
+            .Select(x => new ConsentScopeDto
+            {
+                Name = x.Name,
+                Value = x.Name,
+                DisplayName = x.DisplayName ?? x.Name,
+                Description = x.Description,
+                Emphasize = x.Emphasize,
+                Required = x.Required,
+                Checked = x.Required
+            })
+            .ToList();
+
+        var resourceIndicators = request.Parameters.GetValues(OidcConstants.AuthorizeRequest.Resource) ?? Enumerable.Empty<string>();
+        var apiResources = request.ValidatedResources.Resources.ApiResources.Where(x => resourceIndicators.Contains(x.Name));
+
+        var apiScopes = new List<ConsentScopeDto>();
+        foreach (var parsedScope in request.ValidatedResources.ParsedScopes)
+        {
+            var apiScope = request.ValidatedResources.Resources.FindApiScope(parsedScope.ParsedName);
+            if (apiScope != null)
+            {
+                apiScopes.Add(new ConsentScopeDto
+                {
+                    Name = parsedScope.ParsedName,
+                    Value = parsedScope.RawValue,
+                    DisplayName = apiScope.DisplayName ?? apiScope.Name,
+                    Description = apiScope.Description,
+                    Emphasize = apiScope.Emphasize,
+                    Required = apiScope.Required,
+                    Checked = apiScope.Required
+                });
+            }
+        }
+
+        if (ConsentOptions.EnableOfflineAccess && request.ValidatedResources.Resources.OfflineAccess)
+        {
+            apiScopes.Add(new ConsentScopeDto
+            {
+                Value = Duende.IdentityServer.IdentityServerConstants.StandardScopes.OfflineAccess,
+                DisplayName = ConsentOptions.OfflineAccessDisplayName,
+                Description = ConsentOptions.OfflineAccessDescription,
+                Emphasize = true
+            });
+        }
+
+        return new ConsentContextResponse
+        {
+            ClientName = request.Client.ClientName ?? request.Client.ClientId,
+            ClientUrl = request.Client.ClientUri,
+            ClientLogoUrl = request.Client.LogoUri,
+            AllowRememberConsent = request.Client.AllowRememberConsent,
+            ReturnUrl = returnUrl,
+            IdentityScopes = identityScopes,
+            ApiScopes = apiScopes
+        };
+    }
+}

--- a/src/IdentityService/Services/Account/DeviceFlowService.cs
+++ b/src/IdentityService/Services/Account/DeviceFlowService.cs
@@ -1,0 +1,145 @@
+using System.Security.Claims;
+using Duende.IdentityServer.Events;
+using Duende.IdentityServer.Extensions;
+using Duende.IdentityServer.Models;
+using Duende.IdentityServer.Services;
+using Duende.IdentityServer.Validation;
+using IdentityService.Models.Api.Account;
+using IdentityService.Pages.Consent;
+using IdentityService.Pages.Device;
+using Telemetry = IdentityService.Pages.Telemetry;
+
+namespace IdentityService.Services.Account;
+
+public class DeviceFlowService(IDeviceFlowInteractionService interaction, IEventService events) : IDeviceFlowService
+{
+    public async Task<DeviceContextResponse> GetContextAsync(string userCode)
+    {
+        if (string.IsNullOrWhiteSpace(userCode))
+        {
+            return new DeviceContextResponse { Success = false };
+        }
+
+        var request = await interaction.GetAuthorizationContextAsync(userCode);
+        if (request == null)
+        {
+            return new DeviceContextResponse { Success = false, UserCode = userCode };
+        }
+
+        return CreateDeviceContext(request, userCode);
+    }
+
+    public async Task<DeviceSubmitResponse> SubmitAsync(DeviceSubmitRequest request, ClaimsPrincipal user)
+    {
+        var authRequest = await interaction.GetAuthorizationContextAsync(request.UserCode);
+        if (authRequest == null)
+        {
+            return new DeviceSubmitResponse { Success = false };
+        }
+
+        ConsentResponse grantedConsent = null;
+        var fieldErrors = new FieldErrorsDto();
+
+        if (request.Button == "no")
+        {
+            grantedConsent = new ConsentResponse { Error = AuthorizationError.AccessDenied };
+            await events.RaiseAsync(new ConsentDeniedEvent(user.GetSubjectId(), authRequest.Client.ClientId, authRequest.ValidatedResources.RawScopeValues));
+            Telemetry.Metrics.ConsentDenied(authRequest.Client.ClientId, authRequest.ValidatedResources.ParsedScopes.Select(s => s.ParsedName));
+        }
+        else if (request.Button == "yes")
+        {
+            if (request.ScopesConsented.Any())
+            {
+                var scopes = request.ScopesConsented.ToList();
+                if (ConsentOptions.EnableOfflineAccess == false)
+                {
+                    scopes = scopes.Where(x => x != Duende.IdentityServer.IdentityServerConstants.StandardScopes.OfflineAccess).ToList();
+                }
+
+                grantedConsent = new ConsentResponse
+                {
+                    RememberConsent = request.RememberConsent,
+                    ScopesValuesConsented = scopes.ToArray(),
+                    Description = request.Description
+                };
+
+                await events.RaiseAsync(new ConsentGrantedEvent(user.GetSubjectId(), authRequest.Client.ClientId, authRequest.ValidatedResources.RawScopeValues, grantedConsent.ScopesValuesConsented, grantedConsent.RememberConsent));
+                Telemetry.Metrics.ConsentGranted(authRequest.Client.ClientId, grantedConsent.ScopesValuesConsented, grantedConsent.RememberConsent);
+                var denied = authRequest.ValidatedResources.ParsedScopes.Select(s => s.ParsedName).Except(grantedConsent.ScopesValuesConsented);
+                Telemetry.Metrics.ConsentDenied(authRequest.Client.ClientId, denied);
+            }
+            else
+            {
+                fieldErrors.Errors[""] = [ConsentOptions.MustChooseOneErrorMessage];
+            }
+        }
+        else
+        {
+            fieldErrors.Errors[""] = [ConsentOptions.InvalidSelectionErrorMessage];
+        }
+
+        if (grantedConsent != null)
+        {
+            await interaction.HandleRequestAsync(request.UserCode, grantedConsent);
+            return new DeviceSubmitResponse { Success = true, RedirectUrl = "/device/success" };
+        }
+
+        return new DeviceSubmitResponse { Success = false, FieldErrors = fieldErrors };
+    }
+
+    private static DeviceContextResponse CreateDeviceContext(DeviceFlowAuthorizationRequest request, string userCode)
+    {
+        var identityScopes = request.ValidatedResources.Resources.IdentityResources
+            .Select(x => new ConsentScopeDto
+            {
+                Value = x.Name,
+                DisplayName = x.DisplayName ?? x.Name,
+                Description = x.Description,
+                Emphasize = x.Emphasize,
+                Required = x.Required,
+                Checked = x.Required
+            })
+            .ToList();
+
+        var apiScopes = new List<ConsentScopeDto>();
+        foreach (var parsedScope in request.ValidatedResources.ParsedScopes)
+        {
+            var apiScope = request.ValidatedResources.Resources.FindApiScope(parsedScope.ParsedName);
+            if (apiScope != null)
+            {
+                apiScopes.Add(new ConsentScopeDto
+                {
+                    Value = parsedScope.RawValue,
+                    DisplayName = apiScope.DisplayName ?? apiScope.Name,
+                    Description = apiScope.Description,
+                    Emphasize = apiScope.Emphasize,
+                    Required = apiScope.Required,
+                    Checked = apiScope.Required
+                });
+            }
+        }
+
+        if (DeviceOptions.EnableOfflineAccess && request.ValidatedResources.Resources.OfflineAccess)
+        {
+            apiScopes.Add(new ConsentScopeDto
+            {
+                Value = Duende.IdentityServer.IdentityServerConstants.StandardScopes.OfflineAccess,
+                DisplayName = DeviceOptions.OfflineAccessDisplayName,
+                Description = DeviceOptions.OfflineAccessDescription,
+                Emphasize = true
+            });
+        }
+
+        return new DeviceContextResponse
+        {
+            Success = true,
+            UserCode = userCode,
+            ClientName = request.Client.ClientName ?? request.Client.ClientId,
+            ClientUrl = request.Client.ClientUri,
+            ClientLogoUrl = request.Client.LogoUri,
+            AllowRememberConsent = request.Client.AllowRememberConsent,
+            IdentityScopes = identityScopes,
+            ApiScopes = apiScopes
+        };
+    }
+}

--- a/src/IdentityService/Services/Account/GrantsFlowService.cs
+++ b/src/IdentityService/Services/Account/GrantsFlowService.cs
@@ -1,0 +1,55 @@
+using System.Security.Claims;
+using Duende.IdentityServer.Events;
+using Duende.IdentityServer.Extensions;
+using Duende.IdentityServer.Services;
+using Duende.IdentityServer.Stores;
+using IdentityService.Models.Api.Account;
+using Telemetry = IdentityService.Pages.Telemetry;
+
+namespace IdentityService.Services.Account;
+
+public class GrantsFlowService(
+    IIdentityServerInteractionService interaction,
+    IClientStore clients,
+    IResourceStore resources,
+    IEventService events) : IGrantsFlowService
+{
+    public async Task<GrantsListResponse> GetGrantsAsync(ClaimsPrincipal user)
+    {
+        var grants = await interaction.GetAllUserGrantsAsync();
+        var list = new List<GrantDto>();
+
+        foreach (var grant in grants)
+        {
+            var client = await clients.FindClientByIdAsync(grant.ClientId);
+            if (client != null)
+            {
+                var grantResources = await resources.FindResourcesByScopeAsync(grant.Scopes);
+
+                list.Add(new GrantDto
+                {
+                    ClientId = client.ClientId,
+                    ClientName = client.ClientName ?? client.ClientId,
+                    ClientLogoUrl = client.LogoUri,
+                    ClientUrl = client.ClientUri,
+                    Description = grant.Description,
+                    Created = grant.CreationTime,
+                    Expires = grant.Expiration,
+                    IdentityGrantNames = grantResources.IdentityResources.Select(x => x.DisplayName ?? x.Name).ToArray(),
+                    ApiGrantNames = grantResources.ApiScopes.Select(x => x.DisplayName ?? x.Name).ToArray()
+                });
+            }
+        }
+
+        return new GrantsListResponse { Grants = list };
+    }
+
+    public async Task<RevokeGrantResponse> RevokeGrantAsync(RevokeGrantRequest request, ClaimsPrincipal user)
+    {
+        await interaction.RevokeUserConsentAsync(request.ClientId);
+        await events.RaiseAsync(new GrantsRevokedEvent(user.GetSubjectId(), request.ClientId));
+        Telemetry.Metrics.GrantsRevoked(request.ClientId);
+
+        return new RevokeGrantResponse { Success = true };
+    }
+}

--- a/src/IdentityService/Services/Account/IConsentFlowService.cs
+++ b/src/IdentityService/Services/Account/IConsentFlowService.cs
@@ -1,0 +1,11 @@
+using IdentityService.Models.Api.Account;
+using System.Security.Claims;
+
+namespace IdentityService.Services.Account;
+
+public interface IConsentFlowService
+{
+    Task<ConsentContextResponse> GetContextAsync(string returnUrl);
+
+    Task<ConsentSubmitResponse> SubmitAsync(ConsentSubmitRequest request, ClaimsPrincipal user);
+}

--- a/src/IdentityService/Services/Account/IDeviceFlowService.cs
+++ b/src/IdentityService/Services/Account/IDeviceFlowService.cs
@@ -1,0 +1,11 @@
+using IdentityService.Models.Api.Account;
+using System.Security.Claims;
+
+namespace IdentityService.Services.Account;
+
+public interface IDeviceFlowService
+{
+    Task<DeviceContextResponse> GetContextAsync(string userCode);
+
+    Task<DeviceSubmitResponse> SubmitAsync(DeviceSubmitRequest request, ClaimsPrincipal user);
+}

--- a/src/IdentityService/Services/Account/IGrantsFlowService.cs
+++ b/src/IdentityService/Services/Account/IGrantsFlowService.cs
@@ -1,0 +1,11 @@
+using IdentityService.Models.Api.Account;
+using System.Security.Claims;
+
+namespace IdentityService.Services.Account;
+
+public interface IGrantsFlowService
+{
+    Task<GrantsListResponse> GetGrantsAsync(ClaimsPrincipal user);
+
+    Task<RevokeGrantResponse> RevokeGrantAsync(RevokeGrantRequest request, ClaimsPrincipal user);
+}

--- a/src/IdentityService/Services/Account/ILoginFlowService.cs
+++ b/src/IdentityService/Services/Account/ILoginFlowService.cs
@@ -1,0 +1,12 @@
+using IdentityService.Models.Api.Account;
+
+namespace IdentityService.Services.Account;
+
+public interface ILoginFlowService
+{
+    Task<LoginContextResponse> GetLoginContextAsync(string returnUrl, bool isAuthenticated);
+
+    Task<LoginResponse> LoginAsync(LoginRequest request);
+
+    Task<LoginResponse> CancelLoginAsync(LoginCancelRequest request);
+}

--- a/src/IdentityService/Services/Account/ILogoutFlowService.cs
+++ b/src/IdentityService/Services/Account/ILogoutFlowService.cs
@@ -1,0 +1,11 @@
+using IdentityService.Models.Api.Account;
+using System.Security.Claims;
+
+namespace IdentityService.Services.Account;
+
+public interface ILogoutFlowService
+{
+    Task<LogoutContextResponse> GetLogoutContextAsync(string logoutId, ClaimsPrincipal user);
+
+    Task<LogoutResponse> LogoutAsync(LogoutRequest request, ClaimsPrincipal user, Func<string, string> buildLoggedOutUrl);
+}

--- a/src/IdentityService/Services/Account/IPasswordFlowService.cs
+++ b/src/IdentityService/Services/Account/IPasswordFlowService.cs
@@ -1,0 +1,19 @@
+using IdentityService.Models.Api.Account;
+using System.Security.Claims;
+
+namespace IdentityService.Services.Account;
+
+public interface IPasswordFlowService
+{
+    Task<ForgotPasswordResponse> ForgotPasswordAsync(ForgotPasswordRequest request);
+
+    Task<ValidateResetTokenResponse> ValidateResetTokenAsync(ValidateResetTokenRequest request);
+
+    Task<ResetPasswordResponse> ResetPasswordAsync(ResetPasswordRequest request);
+
+    Task<SelfResetPasswordResponse> SelfResetSendCodeAsync(ClaimsPrincipal user, SelfResetPasswordSendCodeRequest request);
+
+    Task<SelfResetPasswordResponse> SelfResetVerifyCodeAsync(ClaimsPrincipal user, SelfResetPasswordVerifyCodeRequest request);
+
+    Task<SelfResetPasswordResponse> SelfResetChangePasswordAsync(ClaimsPrincipal user, SelfResetPasswordChangeRequest request);
+}

--- a/src/IdentityService/Services/Account/ITwoFactorFlowService.cs
+++ b/src/IdentityService/Services/Account/ITwoFactorFlowService.cs
@@ -1,0 +1,10 @@
+using IdentityService.Models.Api.Account;
+
+namespace IdentityService.Services.Account;
+
+public interface ITwoFactorFlowService
+{
+    Task<TwoFactorResponse> VerifyAsync(TwoFactorVerifyRequest request);
+
+    Task<TwoFactorResponse> ResendAsync(TwoFactorResendRequest request);
+}

--- a/src/IdentityService/Services/Account/IdentityFlowHelpers.cs
+++ b/src/IdentityService/Services/Account/IdentityFlowHelpers.cs
@@ -1,0 +1,17 @@
+using Duende.IdentityServer.Models;
+
+namespace IdentityService.Services.Account;
+
+internal static class IdentityFlowHelpers
+{
+    public static bool IsNativeClient(AuthorizationRequest context)
+    {
+        if (context?.RedirectUri == null)
+        {
+            return false;
+        }
+
+        return !context.RedirectUri.StartsWith("https", StringComparison.Ordinal)
+               && !context.RedirectUri.StartsWith("http", StringComparison.Ordinal);
+    }
+}

--- a/src/IdentityService/Services/Account/LoginFlowService.cs
+++ b/src/IdentityService/Services/Account/LoginFlowService.cs
@@ -1,0 +1,390 @@
+using Contracts.Events;
+using Duende.IdentityServer;
+using Duende.IdentityServer.Events;
+using Duende.IdentityServer.Models;
+using Duende.IdentityServer.Services;
+using Duende.IdentityServer.Stores;
+using IdentityService.Entities;
+using IdentityService.Extensions;
+using IdentityService.Management.Entities;
+using IdentityService.Management.Models;
+using IdentityService.Management.Services;
+using IdentityService.Models;
+using IdentityService.Models.Api.Account;
+using IdentityService.Pages.Account.Login;
+using IdentityService.Security;
+using IdentityService.Services;
+using Microsoft.AspNetCore.Authentication;
+using Microsoft.AspNetCore.Identity;
+using Telemetry = IdentityService.Pages.Telemetry;
+
+namespace IdentityService.Services.Account;
+
+public class LoginFlowService(
+    IIdentityServerInteractionService interaction,
+    IAuthenticationSchemeProvider schemeProvider,
+    IIdentityProviderStore identityProviderStore,
+    IEventService events,
+    UserManager<ApplicationUser> userManager,
+    SignInManager<ApplicationUser> signInManager,
+    UserManager<ManagementUser> managementUserManager,
+    SignInManager<ManagementUser> managementSignInManager,
+    ILogger logger,
+    IPublishService publishService,
+    IMultiUserStoreService multiUserStoreService,
+    ITwoFactorPendingStore twoFactorPendingStore) : ILoginFlowService
+{
+    public async Task<LoginContextResponse> GetLoginContextAsync(string returnUrl, bool isAuthenticated)
+    {
+        var safeReturnUrl = ReturnUrlGuard.NormalizeForIdentityFlow(returnUrl);
+
+        if (isAuthenticated)
+        {
+            return new LoginContextResponse
+            {
+                IsAuthenticated = true,
+                ReturnUrl = safeReturnUrl
+            };
+        }
+
+        var context = await interaction.GetAuthorizationContextAsync(safeReturnUrl);
+
+        if (context?.IdP != null && await schemeProvider.GetSchemeAsync(context.IdP) != null)
+        {
+            var local = context.IdP == IdentityServerConstants.LocalIdentityProvider;
+            var providers = new List<ExternalProviderDto>();
+
+            if (!local)
+            {
+                providers.Add(new ExternalProviderDto
+                {
+                    AuthenticationScheme = context.IdP,
+                    DisplayName = context.IdP
+                });
+            }
+
+            var view = new LoginContextResponse
+            {
+                AllowRememberLogin = LoginOptions.AllowRememberLogin,
+                EnableLocalLogin = local,
+                ShowSignup = !ManagementConstants.ManagementClientIds.Contains(context?.Client?.ClientId ?? ""),
+                ReturnUrl = safeReturnUrl,
+                Username = context.LoginHint,
+                IsExternalLoginOnly = !local && providers.Count == 1,
+                ExternalLoginScheme = !local && providers.Count == 1 ? context.IdP : null,
+                ExternalProviders = providers,
+                IsAuthenticated = false
+            };
+
+            return view;
+        }
+
+        var schemes = await schemeProvider.GetAllSchemesAsync();
+        var allProviders = schemes
+            .Where(x => x.DisplayName != null)
+            .Select(x => new ExternalProviderDto
+            {
+                AuthenticationScheme = x.Name,
+                DisplayName = x.DisplayName ?? x.Name
+            })
+            .ToList();
+
+        var dynamicSchemes = (await identityProviderStore.GetAllSchemeNamesAsync())
+            .Where(x => x.Enabled)
+            .Select(x => new ExternalProviderDto
+            {
+                AuthenticationScheme = x.Scheme,
+                DisplayName = x.DisplayName ?? x.Scheme
+            });
+        allProviders.AddRange(dynamicSchemes);
+
+        var allowLocal = true;
+        var client = context?.Client;
+        if (client != null)
+        {
+            allowLocal = client.EnableLocalLogin;
+            if (client.IdentityProviderRestrictions != null && client.IdentityProviderRestrictions.Count != 0)
+            {
+                allProviders = allProviders
+                    .Where(provider => client.IdentityProviderRestrictions.Contains(provider.AuthenticationScheme))
+                    .ToList();
+            }
+        }
+
+        var enableLocalLogin = allowLocal && LoginOptions.AllowLocalLogin;
+        var isExternalOnly = enableLocalLogin == false && allProviders.Count == 1;
+
+        return new LoginContextResponse
+        {
+            AllowRememberLogin = LoginOptions.AllowRememberLogin,
+            EnableLocalLogin = enableLocalLogin,
+            ShowSignup = !ManagementConstants.ManagementClientIds.Contains(context?.Client?.ClientId ?? ""),
+            ReturnUrl = safeReturnUrl,
+            Username = context?.LoginHint,
+            IsExternalLoginOnly = isExternalOnly,
+            ExternalLoginScheme = isExternalOnly ? allProviders.SingleOrDefault()?.AuthenticationScheme : null,
+            ExternalProviders = allProviders,
+            IsAuthenticated = false
+        };
+    }
+
+    public async Task<LoginResponse> LoginAsync(LoginRequest request)
+    {
+        var returnUrl = ReturnUrlGuard.NormalizeForIdentityFlow(request.ReturnUrl);
+        var context = await interaction.GetAuthorizationContextAsync(returnUrl);
+        var fieldErrors = new FieldErrorsDto();
+
+        if (string.IsNullOrWhiteSpace(request.Username))
+        {
+            fieldErrors.Errors["username"] = ["Email is required."];
+        }
+
+        if (string.IsNullOrWhiteSpace(request.Password))
+        {
+            fieldErrors.Errors["password"] = ["Password is required."];
+        }
+
+        if (fieldErrors.Errors.Count > 0)
+        {
+            return new LoginResponse
+            {
+                Outcome = LoginOutcome.Failed,
+                FieldErrors = fieldErrors
+            };
+        }
+
+        var userStore = await multiUserStoreService.DetermineUserStoreByEmailAsync(request.Username);
+
+        if (context?.Client?.ClientId != null)
+        {
+            var expectedUserStore = await multiUserStoreService.DetermineUserStoreAsync(context.Client.ClientId);
+            if (userStore != expectedUserStore)
+            {
+                await events.RaiseAsync(new UserLoginFailureEvent(request.Username, "user type not allowed for client", clientId: context.Client.ClientId));
+                Telemetry.Metrics.UserLoginFailure(context.Client.ClientId, IdentityServerConstants.LocalIdentityProvider, "user type not allowed for client");
+
+                var clientRequiresManagement = expectedUserStore == ManagementConstants.ManagementUserStore;
+                var errorMessage = clientRequiresManagement
+                    ? "This application is restricted to management users only. Please use a management account to login."
+                    : "This application is not available for management users. Please use a regular user account.";
+
+                fieldErrors.Errors["username"] = [errorMessage];
+                return new LoginResponse { Outcome = LoginOutcome.Failed, FieldErrors = fieldErrors };
+            }
+        }
+
+        if (userStore == ManagementConstants.ManagementUserStore)
+        {
+            return await LoginManagementUserAsync(request, returnUrl, context, fieldErrors);
+        }
+
+        return await LoginApplicationUserAsync(request, returnUrl, context, fieldErrors);
+    }
+
+    public async Task<LoginResponse> CancelLoginAsync(LoginCancelRequest request)
+    {
+        var returnUrl = ReturnUrlGuard.NormalizeForIdentityFlow(request.ReturnUrl);
+        var context = await interaction.GetAuthorizationContextAsync(returnUrl);
+
+        if (context != null)
+        {
+            ArgumentNullException.ThrowIfNull(returnUrl, nameof(returnUrl));
+
+            await interaction.DenyAuthorizationAsync(context, AuthorizationError.AccessDenied);
+
+            return new LoginResponse
+            {
+                Outcome = LoginOutcome.Cancelled,
+                RedirectUrl = returnUrl ?? "/",
+                IsNativeClient = IdentityFlowHelpers.IsNativeClient(context)
+            };
+        }
+
+        return new LoginResponse
+        {
+            Outcome = LoginOutcome.Cancelled,
+            RedirectUrl = "/"
+        };
+    }
+
+    private async Task<LoginResponse> LoginManagementUserAsync(
+        LoginRequest request,
+        string returnUrl,
+        AuthorizationRequest context,
+        FieldErrorsDto fieldErrors)
+    {
+        var managementUser = await managementUserManager.FindByNameAsync(request.Username);
+        if (managementUser != null && !await managementUserManager.IsEmailConfirmedAsync(managementUser))
+        {
+            fieldErrors.Errors["username"] = ["Email is not confirmed. Please confirm your email to login."];
+            return new LoginResponse { Outcome = LoginOutcome.Failed, FieldErrors = fieldErrors };
+        }
+
+        if (managementUser != null && !managementUser.IsActive)
+        {
+            fieldErrors.Errors["username"] = ["Your account is not active. Please contact your administrator to activate your account."];
+            return new LoginResponse { Outcome = LoginOutcome.Failed, FieldErrors = fieldErrors };
+        }
+
+        if (managementUser == null)
+        {
+            await events.RaiseAsync(new UserLoginFailureEvent(request.Username, "invalid credentials", clientId: context?.Client.ClientId));
+            Telemetry.Metrics.UserLoginFailure(context?.Client.ClientId, IdentityServerConstants.LocalIdentityProvider, "invalid credentials");
+            fieldErrors.Errors["username"] = [LoginOptions.InvalidCredentialsErrorMessage];
+            return new LoginResponse { Outcome = LoginOutcome.Failed, FieldErrors = fieldErrors };
+        }
+
+        var result = await managementSignInManager.PasswordSignInAsync(managementUser, request.Password, request.RememberLogin, lockoutOnFailure: false);
+
+        if (result.Succeeded)
+        {
+            await events.RaiseAsync(new UserLoginSuccessEvent(managementUser.UserName, managementUser.Id, managementUser.FullName, clientId: context?.Client.ClientId));
+            Telemetry.Metrics.UserLogin(context?.Client.ClientId, IdentityServerConstants.LocalIdentityProvider);
+
+            managementUser.SetLastLogin();
+            await managementUserManager.UpdateAsync(managementUser);
+
+            return CreateSuccessResponse(returnUrl, context);
+        }
+
+        if (result.RequiresTwoFactor)
+        {
+            return await CreateTwoFactorResponseAsync(
+                managementUser.Email,
+                managementUser.UserName,
+                managementUser.Id,
+                managementUser.FullName,
+                returnUrl,
+                request.RememberLogin,
+                "management",
+                context);
+        }
+
+        if (result.IsLockedOut)
+        {
+            return new LoginResponse { Outcome = LoginOutcome.LockedOut };
+        }
+
+        await events.RaiseAsync(new UserLoginFailureEvent(request.Username, "invalid credentials", clientId: context?.Client.ClientId));
+        Telemetry.Metrics.UserLoginFailure(context?.Client.ClientId, IdentityServerConstants.LocalIdentityProvider, "invalid credentials");
+        fieldErrors.Errors["username"] = [LoginOptions.InvalidCredentialsErrorMessage];
+        return new LoginResponse { Outcome = LoginOutcome.Failed, FieldErrors = fieldErrors };
+    }
+
+    private async Task<LoginResponse> LoginApplicationUserAsync(
+        LoginRequest request,
+        string returnUrl,
+        AuthorizationRequest context,
+        FieldErrorsDto fieldErrors)
+    {
+        var blogsphereUser = await userManager.FindByNameAsync(request.Username);
+        if (blogsphereUser == null)
+        {
+            await events.RaiseAsync(new UserLoginFailureEvent(request.Username, "invalid credentials", clientId: context?.Client.ClientId));
+            Telemetry.Metrics.UserLoginFailure(context?.Client.ClientId, IdentityServerConstants.LocalIdentityProvider, "invalid credentials");
+            fieldErrors.Errors["username"] = [LoginOptions.InvalidCredentialsErrorMessage];
+            return new LoginResponse { Outcome = LoginOutcome.Failed, FieldErrors = fieldErrors };
+        }
+
+        var result = await signInManager.PasswordSignInAsync(blogsphereUser, request.Password, request.RememberLogin, lockoutOnFailure: false);
+
+        if (result.Succeeded)
+        {
+            await events.RaiseAsync(new UserLoginSuccessEvent(blogsphereUser.UserName, blogsphereUser.Id, blogsphereUser.FullName, clientId: context?.Client.ClientId));
+            Telemetry.Metrics.UserLogin(context?.Client.ClientId, IdentityServerConstants.LocalIdentityProvider);
+
+            blogsphereUser.SetLastLogin();
+            await userManager.UpdateAsync(blogsphereUser);
+
+            return CreateSuccessResponse(returnUrl, context);
+        }
+
+        if (result.RequiresTwoFactor)
+        {
+            return await CreateTwoFactorResponseAsync(
+                blogsphereUser.Email,
+                blogsphereUser.UserName,
+                blogsphereUser.Id,
+                blogsphereUser.FullName,
+                returnUrl,
+                request.RememberLogin,
+                "blogsphere",
+                context);
+        }
+
+        if (result.IsLockedOut)
+        {
+            return new LoginResponse { Outcome = LoginOutcome.LockedOut };
+        }
+
+        await events.RaiseAsync(new UserLoginFailureEvent(request.Username, "invalid credentials", clientId: context?.Client.ClientId));
+        Telemetry.Metrics.UserLoginFailure(context?.Client.ClientId, IdentityServerConstants.LocalIdentityProvider, "invalid credentials");
+        fieldErrors.Errors["username"] = [LoginOptions.InvalidCredentialsErrorMessage];
+        return new LoginResponse { Outcome = LoginOutcome.Failed, FieldErrors = fieldErrors };
+    }
+
+    private async Task<LoginResponse> CreateTwoFactorResponseAsync(
+        string email,
+        string userName,
+        string userId,
+        string fullName,
+        string returnUrl,
+        bool rememberLogin,
+        string userType,
+        AuthorizationRequest context)
+    {
+        await events.RaiseAsync(new UserLoginSuccessEvent(userName, userId, fullName, clientId: context?.Client.ClientId));
+        Telemetry.Metrics.UserLogin(context?.Client.ClientId, IdentityServerConstants.LocalIdentityProvider);
+
+        string code;
+        if (userType == "management")
+        {
+            var managementUser = await managementUserManager.FindByEmailAsync(email);
+            code = await managementUserManager.GenerateTwoFactorTokenAsync(managementUser, ManagementConstants.ManagementTwoFactorTokenProvider);
+            await managementUserManager.SetAuthenticationTokenAsync(managementUser, "2Fa", "2FACode", code);
+            await managementUserManager.SetAuthenticationTokenAsync(managementUser, "2Fa", "2FACodeExpiry", DateTime.UtcNow.AddMinutes(5).ToString());
+        }
+        else
+        {
+            var blogsphereUser = await userManager.FindByEmailAsync(email);
+            code = await userManager.GenerateTwoFactorTokenAsync(blogsphereUser, Constants.CustomTwoFactorTokenProvider);
+            await userManager.SetAuthenticationTokenAsync(blogsphereUser, "2Fa", "2FACode", code);
+            await userManager.SetAuthenticationTokenAsync(blogsphereUser, "2Fa", "2FACodeExpiry", DateTime.UtcNow.AddMinutes(5).ToString());
+        }
+
+        logger.Here().Information("Sending 2FA code to {UserType} user {code}", userType, code);
+        await publishService.PublishAsync(new AuthCodeSent
+        {
+            Email = email,
+            Code = code
+        }, Guid.NewGuid().ToString(), new
+        {
+            Purpose = "TwoFactor",
+            UserType = userType
+        });
+
+        var sessionId = twoFactorPendingStore.Create(new TwoFactorPendingState
+        {
+            Email = email,
+            ReturnUrl = returnUrl,
+            RememberMe = rememberLogin,
+            UserType = userType
+        });
+
+        return new LoginResponse
+        {
+            Outcome = LoginOutcome.RequiresTwoFactor,
+            TwoFactorSessionId = sessionId
+        };
+    }
+
+    private static LoginResponse CreateSuccessResponse(string returnUrl, AuthorizationRequest context)
+    {
+        return new LoginResponse
+        {
+            Outcome = LoginOutcome.Success,
+            RedirectUrl = returnUrl ?? "/",
+            IsNativeClient = IdentityFlowHelpers.IsNativeClient(context)
+        };
+    }
+}

--- a/src/IdentityService/Services/Account/LogoutFlowService.cs
+++ b/src/IdentityService/Services/Account/LogoutFlowService.cs
@@ -1,0 +1,102 @@
+using System.Security.Claims;
+using Duende.IdentityServer.Events;
+using Duende.IdentityServer.Extensions;
+using Duende.IdentityServer.Services;
+using IdentityModel;
+using IdentityService.Entities;
+using IdentityService.Models.Api.Account;
+using IdentityService.Pages.Logout;
+using Microsoft.AspNetCore.Authentication;
+using Microsoft.AspNetCore.Identity;
+using Telemetry = IdentityService.Pages.Telemetry;
+
+namespace IdentityService.Services.Account;
+
+public class LogoutFlowService(
+    SignInManager<ApplicationUser> signInManager,
+    IIdentityServerInteractionService interaction,
+    IEventService events,
+    IHttpContextAccessor httpContextAccessor) : ILogoutFlowService
+{
+    public async Task<LogoutContextResponse> GetLogoutContextAsync(string logoutId, ClaimsPrincipal user)
+    {
+        var isAuthenticated = user.Identity?.IsAuthenticated == true;
+        var showLogoutPrompt = LogoutOptions.ShowLogoutPrompt;
+
+        if (!isAuthenticated)
+        {
+            showLogoutPrompt = false;
+        }
+        else
+        {
+            var context = await interaction.GetLogoutContextAsync(logoutId);
+            if (context?.ShowSignoutPrompt == false)
+            {
+                showLogoutPrompt = false;
+            }
+        }
+
+        return new LogoutContextResponse
+        {
+            ShowLogoutPrompt = showLogoutPrompt,
+            LogoutId = logoutId,
+            IsAuthenticated = isAuthenticated
+        };
+    }
+
+    public async Task<LogoutResponse> LogoutAsync(LogoutRequest request, ClaimsPrincipal user, Func<string, string> buildLoggedOutUrl)
+    {
+        if (user.Identity?.IsAuthenticated != true)
+        {
+            return new LogoutResponse
+            {
+                Outcome = LogoutOutcome.NotAuthenticated,
+                RedirectUrl = buildLoggedOutUrl(request.LogoutId)
+            };
+        }
+
+        var logoutId = request.LogoutId;
+        if (string.IsNullOrEmpty(logoutId))
+        {
+            logoutId = await interaction.CreateLogoutContextAsync();
+        }
+
+        await signInManager.SignOutAsync();
+
+        var idp = user.FindFirst(JwtClaimTypes.IdentityProvider)?.Value;
+        await events.RaiseAsync(new UserLogoutSuccessEvent(user.GetSubjectId(), user.GetDisplayName()));
+        Telemetry.Metrics.UserLogout(idp);
+
+        if (idp != null && idp != Duende.IdentityServer.IdentityServerConstants.LocalIdentityProvider)
+        {
+            var httpContext = httpContextAccessor.HttpContext;
+            if (httpContext != null && await httpContext.GetSchemeSupportsSignOutAsync(idp))
+            {
+                return new LogoutResponse
+                {
+                    Outcome = LogoutOutcome.FederatedSignOutRequired,
+                    LogoutId = logoutId,
+                    FederatedSignOutScheme = idp,
+                    RedirectUrl = buildLoggedOutUrl(logoutId)
+                };
+            }
+        }
+
+        return new LogoutResponse
+        {
+            Outcome = LogoutOutcome.Success,
+            LogoutId = logoutId,
+            RedirectUrl = buildLoggedOutUrl(logoutId)
+        };
+    }
+}
+
+internal static class LogoutHttpContextExtensions
+{
+    public static async Task<bool> GetSchemeSupportsSignOutAsync(this HttpContext context, string scheme)
+    {
+        var provider = context.RequestServices.GetRequiredService<IAuthenticationHandlerProvider>();
+        var handler = await provider.GetHandlerAsync(context, scheme);
+        return handler is IAuthenticationSignOutHandler;
+    }
+}

--- a/src/IdentityService/Services/Account/PasswordFlowService.cs
+++ b/src/IdentityService/Services/Account/PasswordFlowService.cs
@@ -1,0 +1,599 @@
+using System.Security.Claims;
+using System.Security.Cryptography;
+using System.Text;
+using Contracts.Events;
+using Duende.IdentityServer.Models;
+using Duende.IdentityServer.Stores;
+using IdentityService.Entities;
+using IdentityService.Extensions;
+using IdentityService.Management.Entities;
+using IdentityService.Management.Models;
+using IdentityService.Management.Services;
+using IdentityService.Models.Api.Account;
+using IdentityService.Security;
+using IdentityService.Services;
+using Microsoft.AspNetCore.Authentication;
+using Microsoft.AspNetCore.Identity;
+using Microsoft.AspNetCore.WebUtilities;
+
+namespace IdentityService.Services.Account;
+
+public class PasswordFlowService(
+    ILogger logger,
+    IMultiUserStoreService multiUserStoreService,
+    IApplicationUserAuthenticationService applicationUserAuthService,
+    IManagementUserAuthenticationService managementUserAuthService,
+    IPublishService publishService,
+    UserManager<ApplicationUser> userManager,
+    UserManager<ManagementUser> managementUserManager,
+    SignInManager<ApplicationUser> signInManager,
+    SignInManager<ManagementUser> managementSignInManager,
+    IPersistedGrantStore persistedGrantStore,
+    IHttpContextAccessor httpContextAccessor) : IPasswordFlowService
+{
+    private const string OtpLoginProvider = "SelfResetPassword";
+    private const string OtpCodeName = "OtpCode";
+    private const string OtpCodeExpiryName = "OtpCodeExpiry";
+    private const string OtpVerifiedName = "OtpVerified";
+    private const int OtpExpiryMinutes = 10;
+
+    public async Task<ForgotPasswordResponse> ForgotPasswordAsync(ForgotPasswordRequest request)
+    {
+        var returnUrl = ReturnUrlGuard.NormalizeForClientApp(request.ReturnUrl, request.ClientId);
+        var fieldErrors = new FieldErrorsDto();
+
+        if (string.IsNullOrWhiteSpace(request.Email))
+        {
+            fieldErrors.Errors["email"] = ["Please enter a valid email address"];
+            return new ForgotPasswordResponse { Success = false, FieldErrors = fieldErrors };
+        }
+
+        try
+        {
+            var email = request.Email.Trim().ToLowerInvariant();
+            var userStore = await multiUserStoreService.DetermineUserStoreByEmailAsync(email);
+
+            logger.Here().Information("=== FORGOT PASSWORD DEBUG === Email: {Email}, UserStore: {UserStore}", email, userStore);
+
+            if (userStore == ManagementConstants.ManagementUserStore)
+            {
+                var tokenResult = await managementUserAuthService.GeneratePasswordResetTokenAsync(email);
+                if (tokenResult.IsSuccess)
+                {
+                    await publishService.PublishAsync<PasswordResetInstructionSent>(new()
+                    {
+                        Email = email,
+                    }, Guid.NewGuid().ToString(), new
+                    {
+                        Token = WebEncoders.Base64UrlEncode(Encoding.UTF8.GetBytes(tokenResult.Token)),
+                        UserType = "management",
+                        ReturnUrl = returnUrl,
+                        ClientId = request.ClientId
+                    });
+                }
+            }
+            else
+            {
+                var tokenResult = await applicationUserAuthService.GeneratePasswordResetTokenAsync(email);
+                if (tokenResult.IsSuccess)
+                {
+                    await publishService.PublishAsync<PasswordResetInstructionSent>(new()
+                    {
+                        Email = email,
+                    }, Guid.NewGuid().ToString(), new
+                    {
+                        Token = WebEncoders.Base64UrlEncode(Encoding.UTF8.GetBytes(tokenResult.Token)),
+                        UserType = "blogsphere",
+                        ReturnUrl = returnUrl,
+                        ClientId = request.ClientId
+                    });
+                }
+            }
+
+            return new ForgotPasswordResponse
+            {
+                Success = true,
+                Message = "If an account with that email exists, password reset instructions have been sent."
+            };
+        }
+        catch (Exception ex)
+        {
+            logger.Here().Error(ex, "Error in password reset for \"{Email}\"", request.Email);
+            return new ForgotPasswordResponse
+            {
+                Success = false,
+                Message = "An error occurred while processing your request. Please try again later."
+            };
+        }
+    }
+
+    public async Task<ValidateResetTokenResponse> ValidateResetTokenAsync(ValidateResetTokenRequest request)
+    {
+        var returnUrl = ReturnUrlGuard.NormalizeForClientApp(request.ReturnUrl, request.ClientId);
+
+        if (string.IsNullOrEmpty(request.Email) || string.IsNullOrEmpty(request.Token))
+        {
+            return new ValidateResetTokenResponse { IsValid = false, ReturnUrl = returnUrl };
+        }
+
+        var decodedToken = Encoding.UTF8.GetString(WebEncoders.Base64UrlDecode(request.Token));
+        var userStore = await multiUserStoreService.DetermineUserStoreByEmailAsync(request.Email);
+
+        if (userStore == ManagementConstants.ManagementUserStore)
+        {
+            var result = await managementUserAuthService.ValidatePasswordResetTokenAsync(request.Email, decodedToken);
+            return new ValidateResetTokenResponse { IsValid = result.IsValid, ReturnUrl = returnUrl };
+        }
+
+        var appResult = await applicationUserAuthService.ValidatePasswordResetTokenAsync(request.Email, decodedToken);
+        return new ValidateResetTokenResponse { IsValid = appResult.IsValid, ReturnUrl = returnUrl };
+    }
+
+    public async Task<ResetPasswordResponse> ResetPasswordAsync(ResetPasswordRequest request)
+    {
+        var returnUrl = ReturnUrlGuard.NormalizeForClientApp(request.ReturnUrl, request.ClientId);
+        var fieldErrors = new FieldErrorsDto();
+
+        if (string.IsNullOrWhiteSpace(request.Password))
+        {
+            fieldErrors.Errors["password"] = ["Password is required."];
+        }
+
+        if (!string.Equals(request.Password, request.ConfirmPassword, StringComparison.Ordinal))
+        {
+            fieldErrors.Errors["confirmPassword"] = ["The password and confirmation password do not match."];
+        }
+
+        if (string.IsNullOrEmpty(request.Email) || string.IsNullOrEmpty(request.Token))
+        {
+            return new ResetPasswordResponse
+            {
+                Success = false,
+                RedirectUrl = $"/Account/Login?returnUrl={Uri.EscapeDataString(returnUrl)}",
+                Message = "Invalid reset request."
+            };
+        }
+
+        if (fieldErrors.Errors.Count > 0)
+        {
+            return new ResetPasswordResponse { Success = false, FieldErrors = fieldErrors };
+        }
+
+        var decodedToken = Encoding.UTF8.GetString(WebEncoders.Base64UrlDecode(request.Token));
+        var userStore = await multiUserStoreService.DetermineUserStoreByEmailAsync(request.Email);
+
+        logger.Here().Information("=== RESET PASSWORD DEBUG === Email: {Email}, UserStore: {UserStore}", request.Email, userStore);
+
+        PasswordResetResult result;
+        string subjectId;
+
+        if (userStore == ManagementConstants.ManagementUserStore)
+        {
+            result = await managementUserAuthService.ResetPasswordAsync(request.Email, decodedToken, request.Password);
+            var managementUser = await managementUserManager.FindByEmailAsync(request.Email);
+            subjectId = managementUser?.Id;
+        }
+        else
+        {
+            result = await applicationUserAuthService.ResetPasswordAsync(request.Email, decodedToken, request.Password);
+            var appUser = await userManager.FindByEmailAsync(request.Email);
+            subjectId = appUser?.Id;
+        }
+
+        if (!result.IsSuccess)
+        {
+            fieldErrors.Errors[""] = [result.ErrorMessage];
+            return new ResetPasswordResponse { Success = false, FieldErrors = fieldErrors };
+        }
+
+        if (!string.IsNullOrEmpty(subjectId))
+        {
+            await RevokeTokensAndSignOutAsync(subjectId, request.Email);
+        }
+
+        return new ResetPasswordResponse
+        {
+            Success = true,
+            RedirectUrl = $"/Account/Login?returnUrl={Uri.EscapeDataString(returnUrl)}"
+        };
+    }
+
+    public async Task<SelfResetPasswordResponse> SelfResetSendCodeAsync(ClaimsPrincipal principal, SelfResetPasswordSendCodeRequest request)
+    {
+        var returnUrl = ReturnUrlGuard.NormalizeForClientApp(request.ReturnUrl, request.ClientId);
+        var currentEmail = GetCurrentUserEmail(principal);
+
+        if (string.IsNullOrWhiteSpace(currentEmail))
+        {
+            return new SelfResetPasswordResponse
+            {
+                Success = false,
+                RedirectUrl = $"/Account/Login?returnUrl={Uri.EscapeDataString(returnUrl)}"
+            };
+        }
+
+        var userStore = await multiUserStoreService.DetermineUserStoreByEmailAsync(currentEmail);
+        var oneTimeCode = RandomNumberGenerator.GetInt32(100000, 1000000).ToString("D6");
+        await SaveOtpAsync(currentEmail, userStore, oneTimeCode, DateTime.UtcNow.AddMinutes(OtpExpiryMinutes), isVerified: false);
+
+        await publishService.PublishAsync(new AuthCodeSent
+        {
+            Email = currentEmail,
+            Code = oneTimeCode
+        }, Guid.NewGuid().ToString(), new
+        {
+            Purpose = "SelfResetPassword",
+            UserType = userStore == ManagementConstants.ManagementUserStore ? "management" : "blogsphere",
+        });
+
+        return new SelfResetPasswordResponse
+        {
+            Success = true,
+            Message = "One-time code sent to your email."
+        };
+    }
+
+    public async Task<SelfResetPasswordResponse> SelfResetVerifyCodeAsync(ClaimsPrincipal principal, SelfResetPasswordVerifyCodeRequest request)
+    {
+        var returnUrl = ReturnUrlGuard.NormalizeForClientApp(request.ReturnUrl, request.ClientId);
+        var currentEmail = GetCurrentUserEmail(principal);
+        var fieldErrors = new FieldErrorsDto();
+
+        if (string.IsNullOrWhiteSpace(currentEmail))
+        {
+            return new SelfResetPasswordResponse
+            {
+                Success = false,
+                RedirectUrl = $"/Account/Login?returnUrl={Uri.EscapeDataString(returnUrl)}"
+            };
+        }
+
+        if (string.IsNullOrWhiteSpace(request.OneTimeCode))
+        {
+            fieldErrors.Errors["oneTimeCode"] = ["One-time code is required."];
+            return new SelfResetPasswordResponse { Success = false, FieldErrors = fieldErrors };
+        }
+
+        var userStore = await multiUserStoreService.DetermineUserStoreByEmailAsync(currentEmail);
+        var (isValid, reason) = await ValidateOtpAsync(currentEmail, userStore, request.OneTimeCode);
+
+        if (!isValid)
+        {
+            fieldErrors.Errors["oneTimeCode"] = [reason];
+            return new SelfResetPasswordResponse { Success = false, FieldErrors = fieldErrors };
+        }
+
+        await SetOtpVerifiedAsync(currentEmail, userStore, isVerified: true);
+
+        return new SelfResetPasswordResponse { Success = true, Message = "Code verified." };
+    }
+
+    public async Task<SelfResetPasswordResponse> SelfResetChangePasswordAsync(ClaimsPrincipal principal, SelfResetPasswordChangeRequest request)
+    {
+        var returnUrl = ReturnUrlGuard.NormalizeForClientApp(request.ReturnUrl, request.ClientId);
+        var currentEmail = GetCurrentUserEmail(principal);
+        var fieldErrors = new FieldErrorsDto();
+
+        if (string.IsNullOrWhiteSpace(currentEmail))
+        {
+            return new SelfResetPasswordResponse
+            {
+                Success = false,
+                RedirectUrl = $"/Account/Login?returnUrl={Uri.EscapeDataString(returnUrl)}"
+            };
+        }
+
+        var userStore = await multiUserStoreService.DetermineUserStoreByEmailAsync(currentEmail);
+        var codeMode = string.Equals(request.Mode, "code", StringComparison.OrdinalIgnoreCase);
+
+        if (codeMode && !await IsOtpVerifiedAsync(currentEmail, userStore))
+        {
+            fieldErrors.Errors[""] = ["One-time code verification is required."];
+            return new SelfResetPasswordResponse { Success = false, FieldErrors = fieldErrors };
+        }
+
+        if (!codeMode && string.IsNullOrWhiteSpace(request.CurrentPassword))
+        {
+            fieldErrors.Errors["currentPassword"] = ["Current password is required."];
+        }
+
+        if (string.IsNullOrWhiteSpace(request.NewPassword))
+        {
+            fieldErrors.Errors["newPassword"] = ["New password is required."];
+        }
+
+        if (!string.Equals(request.NewPassword, request.ConfirmPassword, StringComparison.Ordinal))
+        {
+            fieldErrors.Errors["confirmPassword"] = ["The password and confirmation password do not match."];
+        }
+
+        if (fieldErrors.Errors.Count > 0)
+        {
+            return new SelfResetPasswordResponse { Success = false, FieldErrors = fieldErrors };
+        }
+
+        if (userStore == ManagementConstants.ManagementUserStore)
+        {
+            return await ChangeManagementPasswordAsync(currentEmail, request, codeMode, returnUrl, fieldErrors);
+        }
+
+        return await ChangeApplicationPasswordAsync(currentEmail, request, codeMode, returnUrl, fieldErrors);
+    }
+
+    private async Task<SelfResetPasswordResponse> ChangeManagementPasswordAsync(
+        string currentEmail,
+        SelfResetPasswordChangeRequest request,
+        bool codeMode,
+        string returnUrl,
+        FieldErrorsDto fieldErrors)
+    {
+        var managementUser = await managementUserManager.FindByEmailAsync(currentEmail);
+        if (managementUser == null)
+        {
+            return new SelfResetPasswordResponse
+            {
+                Success = false,
+                RedirectUrl = $"/Account/Login?returnUrl={Uri.EscapeDataString(returnUrl)}"
+            };
+        }
+
+        IdentityResult result;
+        if (codeMode)
+        {
+            await managementUserManager.RemovePasswordAsync(managementUser);
+            result = await managementUserManager.AddPasswordAsync(managementUser, request.NewPassword);
+        }
+        else
+        {
+            var isCurrentPasswordValid = await managementUserManager.CheckPasswordAsync(managementUser, request.CurrentPassword);
+            if (!isCurrentPasswordValid)
+            {
+                fieldErrors.Errors["currentPassword"] = ["Current password is incorrect."];
+                return new SelfResetPasswordResponse { Success = false, FieldErrors = fieldErrors };
+            }
+
+            result = await managementUserManager.ChangePasswordAsync(managementUser, request.CurrentPassword, request.NewPassword);
+        }
+
+        if (!result.Succeeded)
+        {
+            AddIdentityErrors(result, fieldErrors, codeMode);
+            return new SelfResetPasswordResponse { Success = false, FieldErrors = fieldErrors };
+        }
+
+        if (codeMode)
+        {
+            await ClearOtpAsync(currentEmail, ManagementConstants.ManagementUserStore);
+        }
+
+        await RevokeTokensAndSignOutAsync(managementUser.Id, currentEmail);
+        await managementSignInManager.PasswordSignInAsync(managementUser, request.NewPassword, isPersistent: true, lockoutOnFailure: false);
+
+        return new SelfResetPasswordResponse
+        {
+            Success = true,
+            RedirectUrl = AppendPasswordResetParam(returnUrl)
+        };
+    }
+
+    private async Task<SelfResetPasswordResponse> ChangeApplicationPasswordAsync(
+        string currentEmail,
+        SelfResetPasswordChangeRequest request,
+        bool codeMode,
+        string returnUrl,
+        FieldErrorsDto fieldErrors)
+    {
+        var appUser = await userManager.FindByEmailAsync(currentEmail);
+        if (appUser == null)
+        {
+            return new SelfResetPasswordResponse
+            {
+                Success = false,
+                RedirectUrl = $"/Account/Login?returnUrl={Uri.EscapeDataString(returnUrl)}"
+            };
+        }
+
+        IdentityResult result;
+        if (codeMode)
+        {
+            await userManager.RemovePasswordAsync(appUser);
+            result = await userManager.AddPasswordAsync(appUser, request.NewPassword);
+        }
+        else
+        {
+            var isCurrentPasswordValid = await userManager.CheckPasswordAsync(appUser, request.CurrentPassword);
+            if (!isCurrentPasswordValid)
+            {
+                fieldErrors.Errors["currentPassword"] = ["Current password is incorrect."];
+                return new SelfResetPasswordResponse { Success = false, FieldErrors = fieldErrors };
+            }
+
+            result = await userManager.ChangePasswordAsync(appUser, request.CurrentPassword, request.NewPassword);
+        }
+
+        if (!result.Succeeded)
+        {
+            AddIdentityErrors(result, fieldErrors, codeMode);
+            return new SelfResetPasswordResponse { Success = false, FieldErrors = fieldErrors };
+        }
+
+        if (codeMode)
+        {
+            await ClearOtpAsync(currentEmail, ManagementConstants.BlogsphereUserStore);
+        }
+
+        await RevokeTokensAndSignOutAsync(appUser.Id, currentEmail);
+        await signInManager.PasswordSignInAsync(appUser, request.NewPassword, isPersistent: true, lockoutOnFailure: false);
+
+        return new SelfResetPasswordResponse
+        {
+            Success = true,
+            RedirectUrl = AppendPasswordResetParam(returnUrl)
+        };
+    }
+
+    private static void AddIdentityErrors(IdentityResult result, FieldErrorsDto fieldErrors, bool codeMode)
+    {
+        foreach (var error in result.Errors)
+        {
+            var isCurrentPasswordError = !codeMode
+                && (string.Equals(error.Code, "PasswordMismatch", StringComparison.OrdinalIgnoreCase)
+                    || string.Equals(error.Code, "InvalidPassword", StringComparison.OrdinalIgnoreCase)
+                    || error.Description.Contains("incorrect password", StringComparison.OrdinalIgnoreCase)
+                    || error.Description.Contains("password mismatch", StringComparison.OrdinalIgnoreCase));
+
+            if (isCurrentPasswordError)
+            {
+                fieldErrors.Errors["currentPassword"] = [error.Description];
+            }
+            else
+            {
+                if (!fieldErrors.Errors.ContainsKey(""))
+                {
+                    fieldErrors.Errors[""] = [];
+                }
+
+                fieldErrors.Errors[""] = fieldErrors.Errors[""].Append(error.Description).ToArray();
+            }
+        }
+    }
+
+    private async Task RevokeTokensAndSignOutAsync(string subjectId, string email)
+    {
+        await persistedGrantStore.RemoveAllAsync(new PersistedGrantFilter { SubjectId = subjectId });
+        await signInManager.SignOutAsync();
+        await managementSignInManager.SignOutAsync();
+
+        if (httpContextAccessor.HttpContext != null)
+        {
+            await httpContextAccessor.HttpContext.SignOutAsync();
+        }
+
+        logger.Here().Information("Revoked persisted grants and signed out user after password reset for {Email}", email);
+    }
+
+    private static string GetCurrentUserEmail(ClaimsPrincipal principal)
+    {
+        return principal.FindFirstValue(ClaimTypes.Email)
+            ?? principal.FindFirstValue("email")
+            ?? principal.Identity?.Name
+            ?? string.Empty;
+    }
+
+    private static string AppendPasswordResetParam(string url)
+    {
+        if (string.IsNullOrWhiteSpace(url)) return url;
+        var separator = url.Contains('?') ? "&" : "?";
+        return url + separator + "passwordReset=success";
+    }
+
+    private async Task SaveOtpAsync(string email, string userStore, string code, DateTime expiryUtc, bool isVerified)
+    {
+        if (userStore == ManagementConstants.ManagementUserStore)
+        {
+            var user = await managementUserManager.FindByEmailAsync(email);
+            if (user == null) return;
+
+            await managementUserManager.SetAuthenticationTokenAsync(user, OtpLoginProvider, OtpCodeName, code);
+            await managementUserManager.SetAuthenticationTokenAsync(user, OtpLoginProvider, OtpCodeExpiryName, expiryUtc.ToString("O"));
+            await managementUserManager.SetAuthenticationTokenAsync(user, OtpLoginProvider, OtpVerifiedName, isVerified.ToString());
+            return;
+        }
+
+        var appUser = await userManager.FindByEmailAsync(email);
+        if (appUser == null) return;
+
+        await userManager.SetAuthenticationTokenAsync(appUser, OtpLoginProvider, OtpCodeName, code);
+        await userManager.SetAuthenticationTokenAsync(appUser, OtpLoginProvider, OtpCodeExpiryName, expiryUtc.ToString("O"));
+        await userManager.SetAuthenticationTokenAsync(appUser, OtpLoginProvider, OtpVerifiedName, isVerified.ToString());
+    }
+
+    private async Task<(bool isValid, string reason)> ValidateOtpAsync(string email, string userStore, string otpCode)
+    {
+        string savedCode;
+        string expiryRaw;
+
+        if (userStore == ManagementConstants.ManagementUserStore)
+        {
+            var user = await managementUserManager.FindByEmailAsync(email);
+            if (user == null) return (false, "Invalid user.");
+            savedCode = await managementUserManager.GetAuthenticationTokenAsync(user, OtpLoginProvider, OtpCodeName) ?? string.Empty;
+            expiryRaw = await managementUserManager.GetAuthenticationTokenAsync(user, OtpLoginProvider, OtpCodeExpiryName) ?? string.Empty;
+        }
+        else
+        {
+            var appUser = await userManager.FindByEmailAsync(email);
+            if (appUser == null) return (false, "Invalid user.");
+            savedCode = await userManager.GetAuthenticationTokenAsync(appUser, OtpLoginProvider, OtpCodeName) ?? string.Empty;
+            expiryRaw = await userManager.GetAuthenticationTokenAsync(appUser, OtpLoginProvider, OtpCodeExpiryName) ?? string.Empty;
+        }
+
+        return ValidateOtpToken(savedCode, expiryRaw, otpCode);
+    }
+
+    private static (bool isValid, string reason) ValidateOtpToken(string savedCode, string expiryRaw, string otpCode)
+    {
+        if (string.IsNullOrWhiteSpace(savedCode) || string.IsNullOrWhiteSpace(expiryRaw))
+            return (false, "No active one-time code. Please request a new code.");
+
+        if (!DateTime.TryParse(expiryRaw, out var expiryUtc) || DateTime.UtcNow > expiryUtc)
+            return (false, "One-time code expired. Please request a new code.");
+
+        if (!string.Equals(savedCode, otpCode, StringComparison.Ordinal))
+            return (false, "Invalid one-time code.");
+
+        return (true, string.Empty);
+    }
+
+    private async Task SetOtpVerifiedAsync(string email, string userStore, bool isVerified)
+    {
+        if (userStore == ManagementConstants.ManagementUserStore)
+        {
+            var user = await managementUserManager.FindByEmailAsync(email);
+            if (user == null) return;
+            await managementUserManager.SetAuthenticationTokenAsync(user, OtpLoginProvider, OtpVerifiedName, isVerified.ToString());
+            return;
+        }
+
+        var appUser = await userManager.FindByEmailAsync(email);
+        if (appUser == null) return;
+        await userManager.SetAuthenticationTokenAsync(appUser, OtpLoginProvider, OtpVerifiedName, isVerified.ToString());
+    }
+
+    private async Task<bool> IsOtpVerifiedAsync(string email, string userStore)
+    {
+        if (userStore == ManagementConstants.ManagementUserStore)
+        {
+            var user = await managementUserManager.FindByEmailAsync(email);
+            if (user == null) return false;
+            var isVerifiedRaw = await managementUserManager.GetAuthenticationTokenAsync(user, OtpLoginProvider, OtpVerifiedName);
+            return bool.TryParse(isVerifiedRaw, out var isVerified) && isVerified;
+        }
+
+        var appUser = await userManager.FindByEmailAsync(email);
+        if (appUser == null) return false;
+        var appVerifiedRaw = await userManager.GetAuthenticationTokenAsync(appUser, OtpLoginProvider, OtpVerifiedName);
+        return bool.TryParse(appVerifiedRaw, out var appVerified) && appVerified;
+    }
+
+    private async Task ClearOtpAsync(string email, string userStore)
+    {
+        if (userStore == ManagementConstants.ManagementUserStore)
+        {
+            var user = await managementUserManager.FindByEmailAsync(email);
+            if (user == null) return;
+
+            await managementUserManager.RemoveAuthenticationTokenAsync(user, OtpLoginProvider, OtpCodeName);
+            await managementUserManager.RemoveAuthenticationTokenAsync(user, OtpLoginProvider, OtpCodeExpiryName);
+            await managementUserManager.RemoveAuthenticationTokenAsync(user, OtpLoginProvider, OtpVerifiedName);
+            return;
+        }
+
+        var appUser = await userManager.FindByEmailAsync(email);
+        if (appUser == null) return;
+
+        await userManager.RemoveAuthenticationTokenAsync(appUser, OtpLoginProvider, OtpCodeName);
+        await userManager.RemoveAuthenticationTokenAsync(appUser, OtpLoginProvider, OtpCodeExpiryName);
+        await userManager.RemoveAuthenticationTokenAsync(appUser, OtpLoginProvider, OtpVerifiedName);
+    }
+}

--- a/src/IdentityService/Services/Account/TwoFactorFlowService.cs
+++ b/src/IdentityService/Services/Account/TwoFactorFlowService.cs
@@ -1,0 +1,213 @@
+using Contracts.Events;
+using Duende.IdentityServer;
+using Duende.IdentityServer.Events;
+using Duende.IdentityServer.Services;
+using IdentityService.Entities;
+using IdentityService.Extensions;
+using IdentityService.Management.Entities;
+using IdentityService.Management.Models;
+using IdentityService.Models;
+using IdentityService.Models.Api.Account;
+using IdentityService.Security;
+using IdentityService.Services;
+using Microsoft.AspNetCore.Identity;
+using Telemetry = IdentityService.Pages.Telemetry;
+
+namespace IdentityService.Services.Account;
+
+public class TwoFactorFlowService(
+    ILogger logger,
+    UserManager<ApplicationUser> userManager,
+    SignInManager<ApplicationUser> signInManager,
+    UserManager<ManagementUser> managementUserManager,
+    SignInManager<ManagementUser> managementSignInManager,
+    IEventService events,
+    IIdentityServerInteractionService interaction,
+    IPublishService publishService,
+    ITwoFactorPendingStore twoFactorPendingStore) : ITwoFactorFlowService
+{
+    public async Task<TwoFactorResponse> ResendAsync(TwoFactorResendRequest request)
+    {
+        var pending = twoFactorPendingStore.Get(request.TwoFactorSessionId);
+        if (pending == null)
+        {
+            return new TwoFactorResponse { Outcome = TwoFactorOutcome.SessionExpired };
+        }
+
+        var returnUrl = ReturnUrlGuard.NormalizeForIdentityFlow(pending.ReturnUrl);
+
+        if (pending.UserType == "management")
+        {
+            var managementUser = await managementUserManager.FindByEmailAsync(pending.Email);
+            if (managementUser == null)
+            {
+                twoFactorPendingStore.Remove(request.TwoFactorSessionId);
+                return new TwoFactorResponse { Outcome = TwoFactorOutcome.SessionExpired };
+            }
+
+            var code = await managementUserManager.GenerateTwoFactorTokenAsync(managementUser, ManagementConstants.ManagementTwoFactorTokenProvider);
+            await managementUserManager.SetAuthenticationTokenAsync(managementUser, "2Fa", "2FACode", code);
+            await managementUserManager.SetAuthenticationTokenAsync(managementUser, "2Fa", "2FACodeExpiry", DateTime.UtcNow.AddMinutes(5).ToString());
+
+            logger.Here().Information("Resending 2FA code to management user {Email}", pending.Email);
+            await publishService.PublishAsync(new AuthCodeSent
+            {
+                Email = managementUser.Email,
+                Code = code
+            }, Guid.NewGuid().ToString(), new
+            {
+                Purpose = "TwoFactor",
+                UserType = "management"
+            });
+        }
+        else
+        {
+            var user = await userManager.FindByEmailAsync(pending.Email);
+            if (user == null)
+            {
+                twoFactorPendingStore.Remove(request.TwoFactorSessionId);
+                return new TwoFactorResponse { Outcome = TwoFactorOutcome.SessionExpired };
+            }
+
+            var code = await userManager.GenerateTwoFactorTokenAsync(user, Constants.CustomTwoFactorTokenProvider);
+            await userManager.SetAuthenticationTokenAsync(user, "2Fa", "2FACode", code);
+            await userManager.SetAuthenticationTokenAsync(user, "2Fa", "2FACodeExpiry", DateTime.UtcNow.AddMinutes(5).ToString());
+
+            logger.Here().Information("Resending 2FA code to blogsphere user {Email}", pending.Email);
+            await publishService.PublishAsync(new AuthCodeSent
+            {
+                Email = user.Email,
+                Code = code
+            }, Guid.NewGuid().ToString(), new
+            {
+                Purpose = "TwoFactor",
+                UserType = "blogsphere"
+            });
+        }
+
+        twoFactorPendingStore.Refresh(request.TwoFactorSessionId);
+
+        return new TwoFactorResponse
+        {
+            Outcome = TwoFactorOutcome.Success,
+            StatusMessage = "A new verification code has been sent to your email."
+        };
+    }
+
+    public async Task<TwoFactorResponse> VerifyAsync(TwoFactorVerifyRequest request)
+    {
+        var pending = twoFactorPendingStore.Get(request.TwoFactorSessionId);
+        if (pending == null)
+        {
+            return new TwoFactorResponse { Outcome = TwoFactorOutcome.SessionExpired };
+        }
+
+        var returnUrl = ReturnUrlGuard.NormalizeForIdentityFlow(pending.ReturnUrl);
+        var context = await interaction.GetAuthorizationContextAsync(returnUrl);
+        var fieldErrors = new FieldErrorsDto();
+
+        if (string.IsNullOrEmpty(request.Code))
+        {
+            fieldErrors.Errors["code"] = ["Code is required"];
+            twoFactorPendingStore.Refresh(request.TwoFactorSessionId);
+            return new TwoFactorResponse
+            {
+                Outcome = TwoFactorOutcome.Failed,
+                FieldErrors = fieldErrors
+            };
+        }
+
+        if (pending.UserType == "management")
+        {
+            return await VerifyManagementUserAsync(pending, request, returnUrl, context, fieldErrors);
+        }
+
+        return await VerifyApplicationUserAsync(pending, request, returnUrl, context, fieldErrors);
+    }
+
+    private async Task<TwoFactorResponse> VerifyManagementUserAsync(
+        TwoFactorPendingState pending,
+        TwoFactorVerifyRequest request,
+        string returnUrl,
+        Duende.IdentityServer.Models.AuthorizationRequest context,
+        FieldErrorsDto fieldErrors)
+    {
+        var managementUser = await managementUserManager.FindByEmailAsync(pending.Email);
+        if (managementUser == null)
+        {
+            fieldErrors.Errors[""] = ["Invalid user."];
+            twoFactorPendingStore.Refresh(request.TwoFactorSessionId);
+            return new TwoFactorResponse { Outcome = TwoFactorOutcome.Failed, FieldErrors = fieldErrors };
+        }
+
+        var result = await managementUserManager.VerifyTwoFactorTokenAsync(managementUser, ManagementConstants.ManagementTwoFactorTokenProvider, request.Code);
+        if (!result)
+        {
+            fieldErrors.Errors["code"] = ["The code is invalid"];
+            twoFactorPendingStore.Refresh(request.TwoFactorSessionId);
+            return new TwoFactorResponse { Outcome = TwoFactorOutcome.Failed, FieldErrors = fieldErrors };
+        }
+
+        await managementSignInManager.SignInAsync(managementUser, pending.RememberMe);
+        await managementUserManager.RemoveAuthenticationTokenAsync(managementUser, "2Fa", "2FACode");
+        await managementUserManager.RemoveAuthenticationTokenAsync(managementUser, "2Fa", "2FACodeExpiry");
+
+        await events.RaiseAsync(new UserLoginSuccessEvent(managementUser.UserName, managementUser.Id, managementUser.FullName, clientId: context?.Client.ClientId));
+        Telemetry.Metrics.UserLogin(context?.Client.ClientId, IdentityServerConstants.LocalIdentityProvider);
+
+        managementUser.SetLastLogin();
+        await managementUserManager.UpdateAsync(managementUser);
+
+        twoFactorPendingStore.Remove(request.TwoFactorSessionId);
+
+        return new TwoFactorResponse
+        {
+            Outcome = TwoFactorOutcome.Success,
+            RedirectUrl = returnUrl,
+            IsNativeClient = IdentityFlowHelpers.IsNativeClient(context)
+        };
+    }
+
+    private async Task<TwoFactorResponse> VerifyApplicationUserAsync(
+        TwoFactorPendingState pending,
+        TwoFactorVerifyRequest request,
+        string returnUrl,
+        Duende.IdentityServer.Models.AuthorizationRequest context,
+        FieldErrorsDto fieldErrors)
+    {
+        var user = await userManager.FindByEmailAsync(pending.Email);
+        if (user == null)
+        {
+            fieldErrors.Errors[""] = ["Invalid user."];
+            twoFactorPendingStore.Refresh(request.TwoFactorSessionId);
+            return new TwoFactorResponse { Outcome = TwoFactorOutcome.Failed, FieldErrors = fieldErrors };
+        }
+
+        var result = await userManager.VerifyTwoFactorTokenAsync(user, Constants.CustomTwoFactorTokenProvider, request.Code);
+        if (!result)
+        {
+            fieldErrors.Errors["code"] = ["The code is invalid"];
+            twoFactorPendingStore.Refresh(request.TwoFactorSessionId);
+            return new TwoFactorResponse { Outcome = TwoFactorOutcome.Failed, FieldErrors = fieldErrors };
+        }
+
+        await signInManager.SignInAsync(user, pending.RememberMe);
+        await userManager.RemoveAuthenticationTokenAsync(user, "2Fa", "2FACode");
+        await userManager.RemoveAuthenticationTokenAsync(user, "2Fa", "2FACodeExpiry");
+
+        await events.RaiseAsync(new UserLoginSuccessEvent(user.UserName, user.Id, user.FullName, clientId: context?.Client.ClientId));
+        Telemetry.Metrics.UserLogin(context?.Client.ClientId, IdentityServerConstants.LocalIdentityProvider);
+
+        user.SetLastLogin();
+        await userManager.UpdateAsync(user);
+
+        twoFactorPendingStore.Remove(request.TwoFactorSessionId);
+
+        return new TwoFactorResponse
+        {
+            Outcome = TwoFactorOutcome.Success,
+            RedirectUrl = returnUrl,
+            IsNativeClient = IdentityFlowHelpers.IsNativeClient(context)
+        };
+    }
+}

--- a/src/IdentityService/Services/Account/TwoFactorPendingStore.cs
+++ b/src/IdentityService/Services/Account/TwoFactorPendingStore.cs
@@ -1,0 +1,69 @@
+using Microsoft.Extensions.Caching.Memory;
+
+namespace IdentityService.Services.Account;
+
+public class TwoFactorPendingState
+{
+    public string SessionId { get; set; }
+
+    public string Email { get; set; }
+
+    public string UserType { get; set; }
+
+    public string ReturnUrl { get; set; }
+
+    public bool RememberMe { get; set; }
+}
+
+public interface ITwoFactorPendingStore
+{
+    string Create(TwoFactorPendingState state);
+
+    TwoFactorPendingState Get(string sessionId);
+
+    void Refresh(string sessionId);
+
+    void Remove(string sessionId);
+}
+
+public class TwoFactorPendingStore(IMemoryCache cache) : ITwoFactorPendingStore
+{
+    private const string CacheKeyPrefix = "2fa-pending:";
+    private static readonly TimeSpan Expiry = TimeSpan.FromMinutes(10);
+
+    public string Create(TwoFactorPendingState state)
+    {
+        var sessionId = Guid.NewGuid().ToString("N");
+        state.SessionId = sessionId;
+        cache.Set(GetCacheKey(sessionId), state, Expiry);
+        return sessionId;
+    }
+
+    public TwoFactorPendingState Get(string sessionId)
+    {
+        if (string.IsNullOrWhiteSpace(sessionId))
+        {
+            return null;
+        }
+
+        return cache.TryGetValue(GetCacheKey(sessionId), out TwoFactorPendingState state)
+            ? state
+            : null;
+    }
+
+    public void Refresh(string sessionId)
+    {
+        var state = Get(sessionId);
+        if (state != null)
+        {
+            cache.Set(GetCacheKey(sessionId), state, Expiry);
+        }
+    }
+
+    public void Remove(string sessionId)
+    {
+        cache.Remove(GetCacheKey(sessionId));
+    }
+
+    private static string GetCacheKey(string sessionId) => $"{CacheKeyPrefix}{sessionId}";
+}

--- a/src/IdentityService/appsettings.json
+++ b/src/IdentityService/appsettings.json
@@ -31,5 +31,9 @@
   },
   "ConnectionStrings": {
     "Sqlserver": "Server=localhost,1433;Database=IdentityDb;User Id=sa;Password=P@ssw0rd;Encrypt=True;TrustServerCertificate=True;"
+  },
+  "AuthSpa": {
+    "Enabled": false,
+    "BaseUrl": "http://localhost:4201"
   }
 }


### PR DESCRIPTION
## Summary
- Adds Account REST API controller and flow services for Auth SPA migration (login, logout, 2FA, password, consent, grants, device).
- Introduces `AuthSpaOptions` configuration and wires hosting in `HostingExtensions` / `appsettings.json`.
- Documents migration plan in `docs/AUTH_SPA_MIGRATION.md`.

## Test plan
- [ ] Run IdentityService locally and exercise `/api/account/*` endpoints with Auth SPA.
- [ ] Verify existing Razor account flows still work when Auth SPA is disabled.
- [ ] Confirm CORS and antiforgery behavior for SPA origin.


Made with [Cursor](https://cursor.com)