### PR TITLE
fix: smart management employee ID generation

### DIFF
--- a/src/Blogsphere.IdentityService.sln
+++ b/src/Blogsphere.IdentityService.sln
@@ -7,6 +7,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "IdentityService", "Identity
 EndProject
 Project("{E53339B2-1760-4266-BCC7-CA923CBCF16C}") = "docker-compose", "docker-compose.dcproj", "{012EEEC8-A5A0-4374-8737-04148EB599BF}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "IdentityService.Tests", "IdentityService.Tests\IdentityService.Tests.csproj", "{4926FB94-706B-4831-83D2-901F90210815}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -21,6 +23,10 @@ Global
 		{012EEEC8-A5A0-4374-8737-04148EB599BF}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{012EEEC8-A5A0-4374-8737-04148EB599BF}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{012EEEC8-A5A0-4374-8737-04148EB599BF}.Release|Any CPU.Build.0 = Release|Any CPU
+		{4926FB94-706B-4831-83D2-901F90210815}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{4926FB94-706B-4831-83D2-901F90210815}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{4926FB94-706B-4831-83D2-901F90210815}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{4926FB94-706B-4831-83D2-901F90210815}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/src/IdentityService.Tests/IdGeneratorTests.cs
+++ b/src/IdentityService.Tests/IdGeneratorTests.cs
@@ -1,0 +1,108 @@
+using IdentityService.Management.Models.Enums;
+using IdentityService.Models;
+
+namespace IdentityService.Tests;
+
+public class IdGeneratorTests
+{
+    [Theory]
+    [InlineData(nameof(ManagementRoles.Manager), "MGR")]
+    [InlineData(nameof(ManagementRoles.SuperAdmin), "SAD")]
+    [InlineData(nameof(ManagementRoles.Admin), "ADM")]
+    [InlineData(nameof(ManagementRoles.Moderator), "MOD")]
+    [InlineData(nameof(ManagementRoles.Analyst), "ANL")]
+    [InlineData(nameof(ManagementRoles.Support), "SUP")]
+    [InlineData(nameof(ManagementRoles.SystemAdmin), "SYS")]
+    [InlineData("manager", "MGR")]
+    [InlineData("ADM", "ADM")]
+    [InlineData("mgr", "MGR")]
+    public void ResolveRoleAbbreviation_MapsRoleNamesAndAbbreviations(string role, string expected)
+    {
+        var result = IdGenerator.ResolveRoleAbbreviation(role);
+
+        Assert.Equal(expected, result);
+    }
+
+    [Theory]
+    [InlineData("ops", "OPS")]
+    [InlineData(" IT ", "IT")]
+    public void NormalizeDepartment_TrimsAndUppercases(string department, string expected)
+    {
+        var result = IdGenerator.NormalizeDepartment(department);
+
+        Assert.Equal(expected, result);
+    }
+
+    [Fact]
+    public void NewManagementUserId_ManagerRole_UsesAbbreviationNotFullRoleName()
+    {
+        var id = IdGenerator.NewManagementUserId("OPS", nameof(ManagementRoles.Manager));
+
+        Assert.StartsWith("OPSMGR", id);
+        Assert.DoesNotContain("Manager", id);
+        Assert.True(id.Length <= IdGenerator.MaxManagementEmployeeIdLength);
+    }
+
+    [Fact]
+    public void NewManagementUserId_AdminRole_UsesAbbreviation()
+    {
+        var id = IdGenerator.NewManagementUserId("IT", nameof(ManagementRoles.Admin));
+
+        Assert.StartsWith("ITADM", id);
+        Assert.True(id.Length <= IdGenerator.MaxManagementEmployeeIdLength);
+    }
+
+    [Fact]
+    public void NewManagementUserId_PassedAbbreviation_RemainsCompatible()
+    {
+        var id = IdGenerator.NewManagementUserId("IT", "ADM");
+
+        Assert.StartsWith("ITADM", id);
+    }
+
+    [Fact]
+    public void NewManagementUserId_SuperAdminRole_DoesNotEmbedFullRoleName()
+    {
+        var id = IdGenerator.NewManagementUserId("OPS", nameof(ManagementRoles.SuperAdmin));
+
+        Assert.StartsWith("OPSSAD", id);
+        Assert.DoesNotContain("SuperAdmin", id);
+        Assert.True(id.Length <= IdGenerator.MaxManagementEmployeeIdLength);
+    }
+
+    [Fact]
+    public void NewManagementUserId_NormalizesDepartmentCase()
+    {
+        var id = IdGenerator.NewManagementUserId("ops", "manager");
+
+        Assert.StartsWith("OPSMGR", id);
+    }
+
+    [Fact]
+    public void NewManagementUserId_Format_IsDeptRoleDateSuffix()
+    {
+        var id = IdGenerator.NewManagementUserId("OPS", "Manager");
+        var datePart = DateTime.UtcNow.ToString("yyMMdd");
+
+        Assert.StartsWith($"OPSMGR{datePart}", id);
+        Assert.Equal(16, id.Length);
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    public void ResolveRoleAbbreviation_ThrowsForMissingRole(string role)
+    {
+        Assert.Throws<ArgumentException>(() => IdGenerator.ResolveRoleAbbreviation(role));
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    public void NormalizeDepartment_ThrowsForMissingDepartment(string department)
+    {
+        Assert.Throws<ArgumentException>(() => IdGenerator.NormalizeDepartment(department));
+    }
+}

--- a/src/IdentityService.Tests/IdentityService.Tests.csproj
+++ b/src/IdentityService.Tests/IdentityService.Tests.csproj
@@ -1,0 +1,27 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+
+    <IsPackable>false</IsPackable>
+    <IsTestProject>true</IsTestProject>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="coverlet.collector" Version="6.0.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
+    <PackageReference Include="xunit" Version="2.5.3" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Using Include="Xunit" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\IdentityService\IdentityService.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/src/IdentityService/Management/Data/ManagementSeedData.cs
+++ b/src/IdentityService/Management/Data/ManagementSeedData.cs
@@ -174,8 +174,8 @@ public static class ManagementSeedData
         
         var users = new[]
         {
-            new ManagementUser("Super", "Admin", "superadmin@blogsphere.com", "IT") { JobTitle = "System Administrator", EmployeeId = IdGenerator.NewManagementUserId("IT", "ADM") },
-            new ManagementUser("Admin", "User", "admin@blogsphere.com", "IT") { JobTitle = "Administrator", EmployeeId = IdGenerator.NewManagementUserId("IT", "ADM") }
+            new ManagementUser("Super", "Admin", "superadmin@blogsphere.com", "IT") { JobTitle = "System Administrator", EmployeeId = IdGenerator.NewManagementUserId("IT", nameof(ManagementRoles.SuperAdmin)) },
+            new ManagementUser("Admin", "User", "admin@blogsphere.com", "IT") { JobTitle = "Administrator", EmployeeId = IdGenerator.NewManagementUserId("IT", nameof(ManagementRoles.Admin)) }
         };
 
         foreach (var user in users)

--- a/src/IdentityService/Management/Entities/ManagementUser.cs
+++ b/src/IdentityService/Management/Entities/ManagementUser.cs
@@ -64,10 +64,10 @@ public class ManagementUser : IdentityUser
     public string DisplayName => $"{FullName} ({Department})";
     
     /// <summary>
-    /// Generates a management-specific employee ID
+    /// Generates a management-specific employee ID from department and role name or abbreviation.
     /// </summary>
-    /// <param name="department">Department code</param>
-    /// <param name="role">Role abbreviation</param>
+    /// <param name="department">Department code (e.g. IT, OPS)</param>
+    /// <param name="role">Management role name or abbreviation (e.g. Manager, MGR)</param>
     public void GenerateEmployeeId(string department, string role)
     {
         EmployeeId = IdGenerator.NewManagementUserId(department, role);

--- a/src/IdentityService/Models/Constants.cs
+++ b/src/IdentityService/Models/Constants.cs
@@ -1,4 +1,5 @@
 ﻿using IdentityService.Entities;
+using IdentityService.Management.Models.Enums;
 
 namespace IdentityService.Models;
 
@@ -25,6 +26,24 @@ public class LoggerConstants
 /// </summary>
 public static class IdGenerator
 {
+    public const int MaxManagementEmployeeIdLength = 20;
+
+    private static readonly Dictionary<string, string> ManagementRoleAbbreviations = new(StringComparer.OrdinalIgnoreCase)
+    {
+        [nameof(ManagementRoles.SuperAdmin)] = "SAD",
+        [nameof(ManagementRoles.Admin)] = "ADM",
+        [nameof(ManagementRoles.Manager)] = "MGR",
+        [nameof(ManagementRoles.Moderator)] = "MOD",
+        [nameof(ManagementRoles.Analyst)] = "ANL",
+        [nameof(ManagementRoles.Support)] = "SUP",
+        [nameof(ManagementRoles.SystemAdmin)] = "SYS",
+    };
+
+    private static readonly HashSet<string> KnownRoleAbbreviations = new(StringComparer.OrdinalIgnoreCase)
+    {
+        "SAD", "ADM", "MGR", "MOD", "ANL", "SUP", "SYS"
+    };
+
     /// <summary>
     /// Generates a new GUID-based ID for any entity
     /// </summary>
@@ -45,13 +64,63 @@ public static class IdGenerator
     public static string NewShortId() => Guid.NewGuid().ToString("N")[..8].ToUpper();
 
     /// <summary>
-    /// Generates a user-friendly ID for management users
+    /// Normalizes a department code for employee ID generation.
     /// </summary>
-    /// <param name="department">Department code (e.g., "IT", "HR", "SALES")</param>
-    /// <param name="role">Role abbreviation (e.g., "ADM", "MGR", "SUP")</param>
-    /// <returns>A formatted user ID</returns>
-    public static string NewManagementUserId(string department, string role) 
-        => $"{department}{role}{DateTime.UtcNow:yyMMdd}{NewShortId()[..4]}";
+    public static string NormalizeDepartment(string department)
+    {
+        if (string.IsNullOrWhiteSpace(department))
+            throw new ArgumentException("Department is required.", nameof(department));
+
+        return department.Trim().ToUpperInvariant();
+    }
+
+    /// <summary>
+    /// Resolves a management role name or abbreviation to a 3-letter employee ID code.
+    /// </summary>
+    public static string ResolveRoleAbbreviation(string role)
+    {
+        if (string.IsNullOrWhiteSpace(role))
+            throw new ArgumentException("Role is required.", nameof(role));
+
+        var trimmed = role.Trim();
+
+        if (ManagementRoleAbbreviations.TryGetValue(trimmed, out var mappedAbbreviation))
+            return mappedAbbreviation;
+
+        var upper = trimmed.ToUpperInvariant();
+        if (KnownRoleAbbreviations.Contains(upper))
+            return upper;
+
+        if (upper.Length == 3 && upper.All(char.IsLetter))
+            return upper;
+
+        var letters = trimmed.Where(char.IsLetter).Take(3).Select(char.ToUpperInvariant).ToArray();
+        return letters.Length >= 3
+            ? new string(letters, 0, 3)
+            : new string(letters).PadRight(3, 'X');
+    }
+
+    /// <summary>
+    /// Generates a user-friendly ID for management users.
+    /// </summary>
+    /// <param name="department">Department code (e.g., "IT", "OPS")</param>
+    /// <param name="role">Management role name or abbreviation (e.g., "Manager", "MGR")</param>
+    /// <returns>A formatted employee ID: {DEPT}{ROLE_ABBR}{yyMMdd}{4chars}</returns>
+    public static string NewManagementUserId(string department, string role)
+    {
+        var dept = NormalizeDepartment(department);
+        var roleAbbr = ResolveRoleAbbreviation(role);
+        var suffix = NewShortId()[..4];
+        var id = $"{dept}{roleAbbr}{DateTime.UtcNow:yyMMdd}{suffix}";
+
+        if (id.Length > MaxManagementEmployeeIdLength)
+        {
+            throw new InvalidOperationException(
+                $"Employee ID '{id}' exceeds {MaxManagementEmployeeIdLength} characters. Use shorter department/role codes.");
+        }
+
+        return id;
+    }
 }
 
 public static class RolePermissionMap


### PR DESCRIPTION
## Summary
- Map management role names to 3-letter abbreviations when generating employee IDs (e.g. `Manager` → `MGR`)
- Normalize department codes (trim, uppercase) and enforce the 20-character employee ID limit
- Add `IdentityService.Tests` with unit tests for `IdGenerator`
- Update seed data to use role names instead of hardcoded abbreviations

## Problem
Creating a management user with `department: OPS` and `roles: ["Manager"]` produced `OPSManager2606088C89` instead of the intended `OPSMGR260608xxxx` format.

## Test plan
- [x] `dotnet test src/IdentityService.Tests/IdentityService.Tests.csproj` (24 tests passed)
- [ ] Verify new management users receive abbreviated employee IDs on create